### PR TITLE
Chore - Node v4 removed from CI

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,16 @@
+root = true
+
+[*]
+charset = utf-8
+insert_final_newline = true
+end_of_line = lf
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 2
+
+[*.{js}]
+indent_size = 2
+indent_style = space
+
+[*.md]
+insert_final_newline = false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-sudo: false
 language: node_js
 node_js:
     - 6

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,9 @@
 sudo: false
 language: node_js
 node_js:
-    - "4"
-    - "6"
-    - "8"
-    - "node"
-
+    - 6
+    - 8
+    - node
 env:
     - EXPRESS_VERSION="4"
     - EXPRESS_VERSION="5.0.0-alpha.6"

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -23,7 +23,7 @@ declare namespace Celebrate {
     /**
      * The Joi version Celebrate uses internally.
      */
-    export const Joi: joi
+    export const Joi: joi;
 
     /**
      * Examines an error object to determine if it originated from the celebrate middleware.

--- a/package.json
+++ b/package.json
@@ -1,10 +1,11 @@
 {
   "name": "celebrate",
   "version": "7.0.6",
-  "description": "A joi validation middleware for Express.",
+  "description": "A Joi validation middleware for Express.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "scripts": {
+    "clean": "rm -rf coverage",
     "lint": "eslint lib test --fix",
     "test": "npm run lint && jest --ci",
     "benchmark": "node benchmarks/index"
@@ -26,22 +27,22 @@
   },
   "homepage": "https://github.com/arb/celebrate#readme",
   "dependencies": {
-    "escape-html": "1.0.3",
-    "fastseries": "1.7.2",
-    "joi": "12.x.x"
+    "escape-html": "^1.0.3",
+    "fastseries": "^1.7.2",
+    "joi": "^13.1.2"
   },
   "devDependencies": {
-    "@types/express": "4.x.x",
-    "@types/joi": "13.0.0",
-    "artificial": "0.1.x",
-    "benchmark": "2.1.4",
-    "body-parser": "1.18.2",
-    "eslint": "4.19.x",
-    "eslint-config-airbnb-base": "12.1.x",
-    "eslint-plugin-import": "2.11.x",
-    "expect": "21.2.x",
-    "express": "5.0.0-alpha.6",
-    "jest": "21.2.x"
+    "@types/express": "^4.x.x",
+    "@types/joi": "^13.0.7",
+    "artificial": "^0.1.x",
+    "benchmark": "^2.1.4",
+    "body-parser": "^1.18.2",
+    "eslint": "^4.19.x",
+    "eslint-config-airbnb-base": "^12.1.x",
+    "eslint-plugin-import": "^2.11.x",
+    "expect": "^22.4.x",
+    "express": "^5.0.0-alpha.6",
+    "jest": "^22.4.x"
   },
   "engines": {
     "node": ">=4.0.0"


### PR DESCRIPTION
Hello,

I've removed Node v4 from CI because Jest only support >= v6.0.0 ([Jest documentation](https://facebook.github.io/jest/docs/en/troubleshooting.html#compatibility-issues))

Have a nice day,