### PR TITLE
give celebrate-middleware a more suitable name

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -83,7 +83,7 @@ const celebrate = (schema, options) => {
     const key = keys[i];
     rules.set(key, Joi.compile(schema[key]));
   }
-  const middleware = (req, res, next) => {
+  const celebrateMiddleware = (req, res, next) => {
     Series(null, REQ_VALIDATIONS, {
       req,
       options: joiOpts,
@@ -91,9 +91,9 @@ const celebrate = (schema, options) => {
     }, next);
   };
 
-  middleware._schema = schema;
+  celebrateMiddleware._schema = schema;
 
-  return middleware;
+  return celebrateMiddleware;
 };
 
 const errors = () => (err, req, res, next) => {


### PR DESCRIPTION
I'm looking into generating a Swagger specification from Express routes which use celebrate for input validation. Currently when celebrate is added to the router the middleware is named `middleware`. In order to identify that its is a celebrate-middlware I would like it to have a more suitable name such as `celebrateMiddleware` or similar.