### PR TITLE
Code Cleanup and optimizations

### DIFF
--- a/benchmarks/index.js
+++ b/benchmarks/index.js
@@ -1,11 +1,10 @@
-'use strict';
-
 const Benchmark = require('benchmark');
 const { celebrate, Joi } = require('../lib');
+
 const middleware = celebrate({
   body: {
-    name: Joi.string().allow('adam').required()
-  }
+    name: Joi.string().allow('adam').required(),
+  },
 });
 
 const suite = new Benchmark.Suite();
@@ -14,14 +13,14 @@ const noop = () => {};
 suite.add('valid', () => {
   middleware({
     body: {
-      name: 'adam'
+      name: 'adam',
     },
-    method: 'post'
+    method: 'post',
   }, {}, noop);
 }).add('invalid', () => {
   middleware({
     body: {},
-    method: 'post'
+    method: 'post',
   }, {}, noop);
 });
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,16 +1,15 @@
-const Series = require('fastseries')({ results: true });
 const Assert = require('assert');
 const Joi = require('joi');
 const EscapeHtml = require('escape-html');
 const validations = require('./schema');
 
-const CELEBRATED = Symbol('isCelebrate');
+const CELEBRATED = Symbol('CELEBRATED');
 const DEFAULTS = {
   escapeHtml: true,
 };
 
 const validateSource = source =>
-  (config, next) => {
+  (config) => {
     const {
       req,
       options,
@@ -19,7 +18,7 @@ const validateSource = source =>
     const spec = rules.get(source);
 
     if (!spec) {
-      return next(null);
+      return null;
     }
     const result = Joi.validate(req[source], spec, options);
     const {
@@ -28,22 +27,16 @@ const validateSource = source =>
     } = result;
 
     if (value !== undefined) {
-      const descriptor = Object.getOwnPropertyDescriptor(req, source);
-      /* istanbul ignore next */
-      if (descriptor && descriptor.writable) {
-        req[source] = value;
-      } else {
-        Object.defineProperty(req, source, {
-          get() { return value; },
-        });
-      }
+      Object.defineProperty(req, source, {
+        value,
+      });
     }
     if (err) {
       err[CELEBRATED] = true;
       err._meta = { source };
-      return next(err);
+      return err;
     }
-    return next(null);
+    return null;
   };
 
 const validateHeaders = validateSource('headers');
@@ -54,7 +47,7 @@ const maybeValidateBody = (config, callback) => {
   const method = config.req.method.toLowerCase();
 
   if (method === 'get' || method === 'head') {
-    return callback(null);
+    return null;
   }
 
   return validateBody(config, callback);
@@ -83,12 +76,21 @@ const celebrate = (schema, options) => {
   Object.keys(schema).forEach((key) => {
     rules.set(key, Joi.compile(schema[key]));
   });
+
   const middleware = (req, res, next) => {
-    Series(null, REQ_VALIDATIONS, {
+    let stepNumber = 0;
+    let err = null;
+    const config = {
       req,
       options: joiOpts,
       rules,
-    }, next);
+    };
+    do {
+      const step = REQ_VALIDATIONS[stepNumber];
+      err = step(config);
+      stepNumber += 1;
+    } while (stepNumber <= REQ_VALIDATIONS.length - 1 && err === null);
+    next(err);
   };
 
   middleware._schema = schema;

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
   "homepage": "https://github.com/arb/celebrate#readme",
   "dependencies": {
     "escape-html": "1.0.3",
-    "fastseries": "1.7.2",
     "joi": "13.x.x"
   },
   "devDependencies": {


### PR DESCRIPTION
Closes #80
Closes #83

Removed fast-series and just did things using native loops and no callbacks. Saw
about a 1000 ops per second speed improvement. Dropped conditional setting of `req.*` values
and just always use `Object.defineProperty`.