### PR TITLE
Fixed errors Middleware Typing

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -19,7 +19,7 @@ declare namespace Celebrate {
      * Creates a Celebrate error handler middleware function.
      * @returns {Function} an express error handler function
      */
-    function errors(): ErrorRequestHandler;
+    function errors(): () => ErrorRequestHandler;
     /**
      * The Joi version Celebrate uses internally.
      */


### PR DESCRIPTION
The `errors` function is *not* an `ErrorRequestHandler` middleware function, but rather *returns* the `ErrorRequestHandler` middleware function.

As a result, when passing `errors` to `Application.use`, you're unable to call it and forced to just provide the function itself.  This in turn creates an infinite loop as the middleware factory never calls `next`.

This change fixes that issue and allows you to provide `errors()` to `Application.use`.