### PR TITLE
Updated @types/joi to be a dependency instead of devdependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,11 +30,11 @@
   "homepage": "https://github.com/arb/celebrate#readme",
   "dependencies": {
     "escape-html": "1.0.3",
-    "joi": "14.x.x"
+    "joi": "14.x.x",
+    "@types/joi": "14.x.x"
   },
   "devDependencies": {
     "@types/express": "4.x.x",
-    "@types/joi": "14.x.x",
     "artificial": "0.1.x",
     "benchmark": "2.1.x",
     "body-parser": "1.18.x",


### PR DESCRIPTION
This is done as if @types/joi is not installed else where in the project by the user, it will not be installed if the module is used as a dependency, meaning that the types that are required in the type definition file will not be present.