### PR TITLE
Update errors() typedef

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -46,7 +46,7 @@ declare namespace Celebrate {
     /**
      * Creates a Celebrate error handler middleware function.
      */
-    function errors(): () => ErrorRequestHandler;
+    function errors(): ErrorRequestHandler;
     /**
      * The Joi version Celebrate uses internally.
      */


### PR DESCRIPTION
This PR updates the `errors` function type definition to more accurately follow the actual implementation and fix typescript lint errors.