### PR TITLE
Update format + exposes Segments

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ celebrate does not have a default export. The following methods encompass the pu
 Returns a `function` with the middleware signature (`(req, res, next)`).
 
 - `schema` - an `object` where `key` can be one of the values from [`Segments`](#segments) and the `value` is a [joi](https://github.com/hapijs/joi/blob/master/API.md) validation schema. Only the keys specified will be validated against the incoming request object. If you omit a key, that part of the `req` object will not be validated. A schema must contain at least one valid key. 
-- `[joiOptions]` - optional `object` containing joi [options](https://github.com/hapijs/joi/blob/master/API.md#validatevalue-schema-options-callback) that are passed directly into the `validate` function. Defaults to `{ escapeHtml: true }`.
+- `[joiOptions]` - optional `object` containing joi [options](https://github.com/hapijs/joi/blob/master/API.md#anyvalidatevalue-options) that are passed directly into the `validate` function. Defaults to `{ warnings: true }`.
 - `[celebrateOptions]` - an optional `object` with the following keys. Defaults to `{}`.
   - `reqContext` - `bool` value that instructs joi to use the incoming `req` object as the `context` value during joi validation. If set, this will trump the value of `joiOptions.context`. This is useful if you want to validate part of the request object against another part of the request object. See the tests for more details.
 

--- a/README.md
+++ b/README.md
@@ -69,18 +69,18 @@ Example of using celebrate on a single POST route to validate `req.body`.
 ```js
 const express = require('express');
 const BodyParser = require('body-parser');
-const { celebrate, Joi, errors } = require('celebrate');
+const { celebrate, Joi, errors, Segments } = require('celebrate');
 
 const app = express();
 app.use(BodyParser.json());
 
 app.post('/signup', celebrate({
-  body: Joi.object().keys({
+  [Segments.BODY]: Joi.object().keys({
     name: Joi.string().required(),
     age: Joi.number().integer(),
     role: Joi.string().default('admin')
   }),
-  query: {
+  [Segments.QUERY]: {
     token: Joi.string().token().required()
   }
 }), (req, res) => {
@@ -93,13 +93,13 @@ app.use(errors());
 Example of using celebrate to validate all incoming requests to ensure the `token` header is present and matches the supplied regular expression.
 ```js
 const express = require('express');
-const { celebrate, Joi, errors } = require('celebrate');
+const { celebrate, Joi, errors, Segments } = require('celebrate');
 const app = express();
 
 // validate all incoming request headers for the token header
 // if missing or not the correct format, respond with an error
 app.use(celebrate({
-  headers: Joi.object({
+  [Segments.HEADERS]: Joi.object({
     token: Joi.string().required().regex(/abc\d{3}/)
   }).unknown()
 }));
@@ -116,7 +116,7 @@ celebrate does not have a default export. The following methods encompass the pu
 
 Returns a `function` with the middleware signature (`(req, res, next)`).
 
-- `schema` - an `object` where `key` can be one of `'params'`, `'headers'`, `'query'`, `'cookies'`, `'signedCookies'` and `'body'` and the `value` is a [joi](https://github.com/hapijs/joi/blob/master/API.md) validation schema. Only the keys specified will be validated against the incoming request object. If you omit a key, that part of the `req` object will not be validated. A schema must contain at least one valid key. 
+- `schema` - an `object` where `key` can be one of the values from [`Segments`](#segments) and the `value` is a [joi](https://github.com/hapijs/joi/blob/master/API.md) validation schema. Only the keys specified will be validated against the incoming request object. If you omit a key, that part of the `req` object will not be validated. A schema must contain at least one valid key. 
 - `[joiOptions]` - optional `object` containing joi [options](https://github.com/hapijs/joi/blob/master/API.md#validatevalue-schema-options-callback) that are passed directly into the `validate` function. Defaults to `{ escapeHtml: true }`.
 - `[celebrateOptions]` - an optional `object` with the following keys. Defaults to `{}`.
   - `reqContext` - `bool` value that instructs joi to use the incoming `req` object as the `context` value during joi validation. If set, this will trump the value of `joiOptions.context`. This is useful if you want to validate part of the request object against another part of the request object. See the tests for more details.
@@ -130,11 +130,26 @@ If the error format does not suite your needs, you are encouraged to write your 
 Errors origintating from `celebrate()` are objects with the following keys:
 - `joi` - The full [joi error object](https://github.com/hapijs/joi/blob/master/API.md#errors).
 - `meta` - On `object` with the following keys:
-  - `source` - A `string` indicating the step where the validation failed. Will be one of `'params'`, `'headers'`, `'query'`, `'cookies'`, `'signedCookies'`, or `'body'`
+  - `source` - A [`Segments`](#segments) indicating the step where the validation failed.
 
 ### `Joi`
 
 celebrate exports the version of joi it is using internally. For maximum compatibility, you should use this version when creating schemas used with celebrate.
+
+### `Segments`
+
+An enum containing all the segments of `req` objects that celebrate *can* valiate against.
+
+```js
+{
+  BODY: 'body',
+  COOKIES: 'cookies',
+  HEADERS: 'headers',
+  PARAMS: 'params',
+  QUERY: 'query',
+  SIGNEDCOOKIES: 'signedCookies',
+}
+```
 
 ### `isCelebrate(err)`
 
@@ -142,12 +157,12 @@ Returns `true` if the provided `err` object originated from the `celebrate` midd
 
 - `err` - an error object
 
-### `format(err, source, [opts])`
+### `format(err, segment, [opts])`
 
 Formats the incomming values into the shape of celebrate [errors](#errors())
 
 - `err` - a Joi validation error object
-- `source` - A `string` indicating the step where the validation failed. Will be one of `'params'`, `'headers'`, `'query'`, `'cookies'`, `'signedCookies'`, or `'body'`
+- `source` - A [`Segment`](#segments) indicating the step where the validation failed.
 - `[opts]` - optional `object` with the following keys
   - `celebrated` -  `bool` that, when `true`, adds `Symbol('celebrated'): true` to the result object. This indicates this error as originating from `celebrate`. You'd likely want to set this to `true` if you want the celebrate error handler to handle errors originating from the `format` function that you call in user-land code. Defaults to `false`. 
 <details>
@@ -155,7 +170,7 @@ Formats the incomming values into the shape of celebrate [errors](#errors())
 
   ```js
     const result = Joi.validate(req.params.id, Joi.string().valid('foo'), { abortEarly: false });
-    const err = format(result, 'params');
+    const err = format(result.error, Segments.PARAMS);
   ```
 </details>
 

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -1,8 +1,8 @@
 exports.segments = {
+  BODY: 'body',
+  COOKIES: 'cookies',
   HEADERS: 'headers',
   PARAMS: 'params',
   QUERY: 'query',
-  COOKIES: 'cookies',
   SIGNEDCOOKIES: 'signedCookies',
-  BODY: 'body',
 };

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -6,6 +6,15 @@ import {
     ValidationResult 
 } from '@hapi/joi';
 
+enum Segments {
+    PARAMS="params",
+    HEADERS="headers",
+    QUERY="query",
+    COOKIES="cookies",
+    SIGNEDCOOKIES="signedCookies",
+    BODY="body"
+}
+
 declare namespace Celebrate {
     /**
     * Creates a Celebrate middleware function.
@@ -60,14 +69,18 @@ declare namespace Celebrate {
     /**
      * Format a joi error into a standard object
      */
-    function format(err: ValidationResult<object>, 
-        source: "params" | "headers" | "query" | "cookies" | "signedCookies" | "body", 
+    function format(err: ValidationError, 
+        source: Segment,
         opts?: { celebrated: boolean }): {
         meta: {
-            source: "params" | "headers" | "query" | "cookies" | "signedCookies" | "body"
+            source: Segment
         },
         joi: ValidationError,
-    }
+    };
+    /**
+     * The different segments of req celebrate can valiate against
+     */
+    export const Segments: Segments;
 }
 
 export = Celebrate;

--- a/lib/index.js
+++ b/lib/index.js
@@ -14,6 +14,10 @@ const internals = {
   DEFAULT_FORMAT_OPTIONS: {
     celebrated: true,
   },
+  emptyBodyValidation: {
+    value: null,
+    segment: segments.BODY,
+  },
 };
 
 internals.format = (error, segment, opts) => ({
@@ -27,24 +31,21 @@ internals.validateSource = (segment) => (spec) => ({
   req,
 }) => new Promise((resolve, reject) => {
   spec.validateAsync(req[segment], config).then(({ value }) => {
-    if (value != null) {
-      Object.defineProperty(req, segment, {
-        value,
-      });
-    }
-    resolve(null);
+    resolve({
+      value,
+      segment,
+    });
   }).catch((e) => reject(internals.format(e, segment, internals.DEFAULT_FORMAT_OPTIONS)));
 });
 
-internals.validateBody = internals.validateSource(segments.BODY);
 internals.maybeValidateBody = (spec) => (opts) => {
   const method = opts.req.method.toLowerCase();
 
   if (method === 'get' || method === 'head') {
-    return Promise.resolve(null);
+    return Promise.resolve(internals.emptyBodyValidation);
   }
 
-  return internals.validateBody(spec)(opts);
+  return internals.validateSource(segments.BODY)(spec)(opts);
 };
 
 // Map of segments to validation functions.
@@ -59,10 +60,16 @@ internals.REQ_VALIDATIONS = new Map([
 ]);
 
 internals.check = (steps, opts) => {
-  const step = steps.shift();
-
-  if (step) {
-    return step(opts).then(() => internals.check(steps, opts));
+  const validateFn = steps.shift();
+  if (validateFn) {
+    return validateFn(opts).then(({ value, segment }) => {
+      if (value != null) {
+        Object.defineProperty(opts.req, segment, {
+          value,
+        });
+      }
+      return internals.check(steps, opts);
+    });
   }
   // If we get here, all the promises have resolved
   // and so we have a final resolve to end the recursion
@@ -75,11 +82,12 @@ exports.celebrate = (schema, joiOpts = {}, celebrateOptions = {}) => {
   result = celebrateSchema.validate(celebrateOptions);
   Assert.ifError(result.error);
 
+  // We want a fresh copy of steps since `internals.check` mutates the array
   const steps = [];
-  internals.REQ_VALIDATIONS.forEach((value, segment) => {
+  internals.REQ_VALIDATIONS.forEach((validateFn, segment) => {
     const spec = schema[segment];
     if (spec) {
-      steps.push(value(Joi.compile(spec)));
+      steps.push(validateFn(Joi.compile(spec)));
     }
   });
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,7 +1,6 @@
 const Assert = require('assert');
 const Joi = require('@hapi/joi');
 const EscapeHtml = require('escape-html');
-const get = require('lodash.get');
 const {
   middlewareSchema,
   celebrateSchema,
@@ -17,24 +16,24 @@ const internals = {
   },
 };
 
-internals.format = (error, source, opts) => ({
+internals.format = (error, segment, opts) => ({
   [internals.CELEBRATED]: opts.celebrated,
   joi: error,
-  meta: { source },
+  meta: { source: segment },
 });
 
-internals.validateSource = (source) => (spec) => ({
+internals.validateSource = (segment) => (spec) => ({
   config,
   req,
 }) => new Promise((resolve, reject) => {
-  spec.validateAsync(req[source], config).then(({ value }) => {
+  spec.validateAsync(req[segment], config).then(({ value }) => {
     if (value != null) {
-      Object.defineProperty(req, source, {
+      Object.defineProperty(req, segment, {
         value,
       });
     }
     resolve(null);
-  }).catch((e) => reject(internals.format(e, source, internals.DEFAULT_FORMAT_OPTIONS)));
+  }).catch((e) => reject(internals.format(e, segment, internals.DEFAULT_FORMAT_OPTIONS)));
 });
 
 internals.validateBody = internals.validateSource(segments.BODY);
@@ -77,8 +76,8 @@ exports.celebrate = (schema, joiOpts = {}, celebrateOptions = {}) => {
   Assert.ifError(result.error);
 
   const steps = [];
-  internals.REQ_VALIDATIONS.forEach((value, key) => {
-    const spec = schema[key];
+  internals.REQ_VALIDATIONS.forEach((value, segment) => {
+    const spec = schema[segment];
     if (spec) {
       steps.push(value(Joi.compile(spec)));
     }
@@ -144,19 +143,16 @@ exports.errors = () => (err, req, res, next) => {
   return res.status(400).send(result);
 };
 
-exports.format = (err, source, opts = { celebrated: false }) => {
-  Assert.ok(get(err, 'error.isJoi', false));
+exports.format = (error, segment, opts = { celebrated: false }) => {
+  Assert.ok(error.isJoi);
 
-  let result = sourceSchema.validate(source);
+  let result = sourceSchema.validate(segment);
   Assert.ifError(result.error);
   result = optSchema.validate(opts);
   Assert.ifError(result.error);
 
-  const {
-    error,
-  } = err;
-
-  return internals.format(error, source, opts);
+  return internals.format(error, segment, opts);
 };
 
 exports.Joi = Joi;
+exports.Segments = segments;

--- a/lib/index.js
+++ b/lib/index.js
@@ -14,10 +14,6 @@ const internals = {
   DEFAULT_FORMAT_OPTIONS: {
     celebrated: true,
   },
-  emptyBodyValidation: {
-    value: null,
-    segment: segments.BODY,
-  },
 };
 
 internals.format = (error, segment, opts) => ({
@@ -26,7 +22,7 @@ internals.format = (error, segment, opts) => ({
   meta: { source: segment },
 });
 
-internals.validateSource = (segment) => (spec) => ({
+internals.validateSource = (segment, spec) => ({
   config,
   req,
 }) => new Promise((resolve, reject) => {
@@ -38,27 +34,31 @@ internals.validateSource = (segment) => (spec) => ({
   }).catch((e) => reject(internals.format(e, segment, internals.DEFAULT_FORMAT_OPTIONS)));
 });
 
-internals.maybeValidateBody = (spec) => (opts) => {
+internals.maybeValidateBody = (segment, spec) => (opts) => {
   const method = opts.req.method.toLowerCase();
 
   if (method === 'get' || method === 'head') {
-    return Promise.resolve(internals.emptyBodyValidation);
+    return Promise.resolve({
+      value: null,
+      segment,
+    });
   }
 
-  return internals.validateSource(segments.BODY)(spec)(opts);
+  return internals.validateSource(segment, spec)(opts);
 };
 
 // Map of segments to validation functions.
 // The key order is the order validations will run in.
 internals.REQ_VALIDATIONS = new Map([
-  [segments.HEADERS, internals.validateSource(segments.HEADERS)],
-  [segments.PARAMS, internals.validateSource(segments.PARAMS)],
-  [segments.QUERY, internals.validateSource(segments.QUERY)],
-  [segments.COOKIES, internals.validateSource(segments.COOKIES)],
-  [segments.SIGNEDCOOKIES, internals.validateSource(segments.SIGNEDCOOKIES)],
+  [segments.HEADERS, internals.validateSource],
+  [segments.PARAMS, internals.validateSource],
+  [segments.QUERY, internals.validateSource],
+  [segments.COOKIES, internals.validateSource],
+  [segments.SIGNEDCOOKIES, internals.validateSource],
   [segments.BODY, internals.maybeValidateBody],
 ]);
 
+// ⚠️ steps is mutated in this function
 internals.check = (steps, opts) => {
   const validateFn = steps.shift();
   if (validateFn) {
@@ -87,7 +87,7 @@ exports.celebrate = (schema, joiOpts = {}, celebrateOptions = {}) => {
   internals.REQ_VALIDATIONS.forEach((validateFn, segment) => {
     const spec = schema[segment];
     if (spec) {
-      steps.push(validateFn(Joi.compile(spec)));
+      steps.push(validateFn(segment, Joi.compile(spec)));
     }
   });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "celebrate",
-  "version": "10.0.1",
+  "version": "10.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -4784,11 +4784,6 @@
       "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
       "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=",
       "dev": true
-    },
-    "lodash.get": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
-      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
     },
     "lodash.sortby": {
       "version": "4.7.0",

--- a/package.json
+++ b/package.json
@@ -30,8 +30,7 @@
   "homepage": "https://github.com/arb/celebrate#readme",
   "dependencies": {
     "@hapi/joi": "16.x.x",
-    "escape-html": "1.0.3",
-    "lodash.get": "4.4.x"
+    "escape-html": "1.0.3"
   },
   "devDependencies": {
     "@hapi/teamwork": "3.3.x",

--- a/test/__snapshots__/celebrate.test.js.snap
+++ b/test/__snapshots__/celebrate.test.js.snap
@@ -41,6 +41,26 @@ Object {
 }
 `;
 
+exports[`format() [async] returns a formatted error object without options 1`] = `
+Object {
+  "joi": [ValidationError: "value" must be [foo]],
+  "meta": Object {
+    "source": "body",
+  },
+  Symbol(celebrated): false,
+}
+`;
+
+exports[`format() [sync] returns a formatted error object without options 1`] = `
+Object {
+  "joi": [ValidationError: "value" must be [foo]],
+  "meta": Object {
+    "source": "body",
+  },
+  Symbol(celebrated): false,
+}
+`;
+
 exports[`format() returns a formatted error object with options 1`] = `
 Object {
   "joi": [ValidationError: "value" must be [foo]],
@@ -48,15 +68,5 @@ Object {
     "source": "body",
   },
   Symbol(celebrated): true,
-}
-`;
-
-exports[`format() returns a formatted error object without options 1`] = `
-Object {
-  "joi": [ValidationError: "value" must be [foo]],
-  "meta": Object {
-    "source": "body",
-  },
-  Symbol(celebrated): false,
 }
 `;

--- a/test/celebrate.test.js
+++ b/test/celebrate.test.js
@@ -7,6 +7,7 @@ const {
   errors,
   isCelebrate,
   format,
+  Segments,
 } = require('../lib');
 
 
@@ -16,7 +17,7 @@ describe('celebrate()', () => {
     ${false}
     ${undefined}
     ${{}}
-    ${{ query: { name: Joi.string(), age: Joi.number() }, foo: Joi.string() }}
+    ${{ [Segments.QUERY]: { name: Joi.string(), age: Joi.number() }, foo: Joi.string() }}
     `('celebrate($schema)', ({ schema }) => {
   it('throws an error', () => {
     expect(() => {
@@ -27,12 +28,12 @@ describe('celebrate()', () => {
 
   describe.each`
     segment | schema | req | message
-    ${'headers'} | ${{ headers: { accept: Joi.string().regex(/xml/) } }} | ${{ headers: { accept: 'application/json' } }} | ${'"accept" with value "application/json" fails to match the required pattern: /xml/'}
-    ${'params'} | ${{ params: { id: Joi.string().token() } }} | ${{ params: { id: '@@@' } }} | ${'"id" must only contain alpha-numeric and underscore characters'}
-    ${'query'} | ${{ query: Joi.object().keys({ start: Joi.date() }) }} | ${{ query: { end: random.number() } }} | ${'"end" is not allowed'}
-    ${'body'} | ${{ body: { first: Joi.string().required(), last: Joi.string(), role: Joi.number().integer() } }} | ${{ body: { first: name.firstName(), last: random.number() }, method: 'POST' }} | ${'"last" must be a string'}
-    ${'cookies'} | ${{ cookies: { state: Joi.string().required() } }} | ${{ cookies: { state: random.number() } }} | ${'"state" must be a string'}
-    ${'signedCookies'} | ${{ signedCookies: { uid: Joi.string().required() } }} | ${{ signedCookies: { uid: random.number() } }} | ${'"uid" must be a string'}
+    ${Segments.HEADERS} | ${{ [Segments.HEADERS]: { accept: Joi.string().regex(/xml/) } }} | ${{ [Segments.HEADERS]: { accept: 'application/json' } }} | ${'"accept" with value "application/json" fails to match the required pattern: /xml/'}
+    ${Segments.PARAMS} | ${{ [Segments.PARAMS]: { id: Joi.string().token() } }} | ${{ [Segments.PARAMS]: { id: '@@@' } }} | ${'"id" must only contain alpha-numeric and underscore characters'}
+    ${Segments.QUERY} | ${{ [Segments.QUERY]: Joi.object().keys({ start: Joi.date() }) }} | ${{ [Segments.QUERY]: { end: random.number() } }} | ${'"end" is not allowed'}
+    ${Segments.BODY} | ${{ [Segments.BODY]: { first: Joi.string().required(), last: Joi.string(), role: Joi.number().integer() } }} | ${{ [Segments.BODY]: { first: name.firstName(), last: random.number() }, method: 'POST' }} | ${'"last" must be a string'}
+    ${Segments.COOKIES} | ${{ [Segments.COOKIES]: { state: Joi.string().required() } }} | ${{ [Segments.COOKIES]: { state: random.number() } }} | ${'"state" must be a string'}
+    ${Segments.SIGNEDCOOKIES} | ${{ [Segments.SIGNEDCOOKIES]: { uid: Joi.string().required() } }} | ${{ [Segments.SIGNEDCOOKIES]: { uid: random.number() } }} | ${'"uid" must be a string'}
     `('celebate middleware', ({
   schema, req, message, segment,
 }) => {
@@ -51,13 +52,13 @@ describe('celebrate()', () => {
   it('errors on the first validation problem (params, query, body)', () => {
     expect.assertions(3);
     const middleware = celebrate({
-      params: {
+      [Segments.PARAMS]: {
         id: Joi.string().required(),
       },
-      query: Joi.object().keys({
+      [Segments.QUERY]: Joi.object().keys({
         start: Joi.date(),
       }),
-      body: {
+      [Segments.BODY]: {
         first: Joi.string().required(),
         last: Joi.string(),
         role: Joi.number().integer(),
@@ -65,20 +66,20 @@ describe('celebrate()', () => {
     });
 
     return middleware({
-      params: {
+      [Segments.PARAMS]: {
         id: random.alphaNumeric(10),
       },
-      query: {
+      [Segments.QUERY]: {
         end: random.boolean(),
       },
-      body: {
+      [Segments.BODY]: {
         first: name.firstName(),
         last: name.lastName(),
       },
     }, null, (err) => {
       expect(isCelebrate(err)).toBe(true);
       expect(err.joi.details[0].message).toBe('"end" is not allowed');
-      expect(err.meta.source).toBe('query');
+      expect(err.meta.source).toBe(Segments.QUERY);
     });
   });
 
@@ -87,20 +88,20 @@ describe('celebrate()', () => {
     const last = name.lastName();
     const role = name.jobTitle();
     const req = {
-      body: {
+      [Segments.BODY]: {
         first,
         last,
       },
-      query: undefined,
+      [Segments.QUERY]: undefined,
       method: 'POST',
     };
     const middleware = celebrate({
-      body: {
+      [Segments.BODY]: {
         first: Joi.string().required(),
         last: Joi.string(),
         role: Joi.number().integer().default(role),
       },
-      query: Joi.number(),
+      [Segments.QUERY]: Joi.number(),
     });
 
     return middleware(req, null, (err) => {
@@ -117,7 +118,7 @@ describe('celebrate()', () => {
   it('does not validate req.body if the method is "GET" or "HEAD"', () => {
     expect.assertions(1);
     const middleware = celebrate({
-      body: {
+      [Segments.BODY]: {
         first: Joi.string().required(),
         last: Joi.string(),
         role: Joi.number().integer(),
@@ -125,7 +126,7 @@ describe('celebrate()', () => {
     });
 
     return middleware({
-      body: {
+      [Segments.BODY]: {
         first: name.firstName(),
         last: name.lastName(),
       },
@@ -152,14 +153,14 @@ describe('celebrate()', () => {
     }));
 
     const middleware = celebrate({
-      body: {
+      [Segments.BODY]: {
         first: f.john(),
         role: f.number().integer(),
       },
     });
 
     return middleware({
-      body: {
+      [Segments.BODY]: {
         first: name.firstName(),
         role: random.number(),
       },
@@ -173,12 +174,12 @@ describe('celebrate()', () => {
   it('uses the supplied the Joi options', () => {
     expect.assertions(2);
     const middleware = celebrate({
-      query: Joi.object().keys({
+      [Segments.QUERY]: Joi.object().keys({
         page: Joi.number(),
       }),
     }, { stripUnknown: true });
     const req = {
-      query: {
+      [Segments.QUERY]: {
         start: date.recent(),
         page: 1,
       },
@@ -194,13 +195,13 @@ describe('celebrate()', () => {
   it('honors the escapeHtml Joi option', () => {
     expect.assertions(2);
     const middleware = celebrate({
-      headers: {
+      [Segments.HEADERS]: {
         accept: Joi.string().regex(/xml/),
       },
     }, { escapeHtml: false });
 
     return middleware({
-      headers: {
+      [Segments.HEADERS]: {
         accept: 'application/json',
       },
     }, null, (err) => {
@@ -212,7 +213,7 @@ describe('celebrate()', () => {
   it('supports static reference', () => {
     expect.assertions(2);
     const middleware = celebrate({
-      body: {
+      [Segments.BODY]: {
         id: Joi.number().valid(Joi.ref('$id')),
       },
     }, {
@@ -223,7 +224,7 @@ describe('celebrate()', () => {
 
     return middleware({
       method: 'POST',
-      body: {
+      [Segments.BODY]: {
         id: random.number({ min: 1, max: 99 }),
       },
     }, null, (err) => {
@@ -235,10 +236,10 @@ describe('celebrate()', () => {
   it('supports a request reference', () => {
     expect.assertions(2);
     const middleware = celebrate({
-      params: {
+      [Segments.PARAMS]: {
         userId: Joi.number().integer().required(),
       },
-      body: {
+      [Segments.BODY]: {
         id: Joi.number().valid(Joi.ref('$params.userId')),
       },
     }, null, {
@@ -247,10 +248,10 @@ describe('celebrate()', () => {
 
     return middleware({
       method: 'POST',
-      params: {
+      [Segments.PARAMS]: {
         userId: 10,
       },
-      body: {
+      [Segments.BODY]: {
         id: random.number({ min: 1, max: 9 }),
       },
     }, null, (err) => {
@@ -264,7 +265,7 @@ describe('errors()', () => {
   it('responds with a joi error from celebrate middleware', () => {
     expect.assertions(3);
     const middleware = celebrate({
-      query: {
+      [Segments.QUERY]: {
         role: Joi.number().integer().min(4),
       },
     });
@@ -283,7 +284,7 @@ describe('errors()', () => {
     };
 
     return middleware({
-      query: {
+      [Segments.QUERY]: {
         role: random.number({ min: 0, max: 3 }),
       },
       method: 'GET',
@@ -316,7 +317,7 @@ describe('errors()', () => {
   it('only includes key values if joi returns details', () => {
     expect.assertions(3);
     const middleware = celebrate({
-      body: {
+      [Segments.BODY]: {
         first: Joi.string().required(),
       },
     });
@@ -335,7 +336,7 @@ describe('errors()', () => {
     };
 
     return middleware({
-      body: {
+      [Segments.BODY]: {
         role: random.word(),
       },
       method: 'POST',
@@ -348,7 +349,7 @@ describe('errors()', () => {
   it('includes more information when abourtEarly is false', () => {
     expect.assertions(3);
     const middleware = celebrate({
-      query: {
+      [Segments.QUERY]: {
         role: Joi.number().required().integer().min(4),
         name: Joi.string().required(),
       },
@@ -370,7 +371,7 @@ describe('errors()', () => {
     };
 
     return middleware({
-      query: {
+      [Segments.QUERY]: {
         role: random.number({ min: 0, max: 3 }),
       },
       method: 'GET',
@@ -399,13 +400,13 @@ describe('isCelebrate()', () => {
   it('returns true if the error object came from celebrate', () => {
     expect.assertions(1);
     const middleware = celebrate({
-      headers: {
+      [Segments.HEADERS]: {
         accept: Joi.string().regex(/xml/),
       },
     });
 
     return middleware({
-      headers: {
+      [Segments.HEADERS]: {
         accept: random.number(),
       },
     }, null, (err) => {
@@ -415,13 +416,15 @@ describe('isCelebrate()', () => {
 });
 
 describe('format()', () => {
+  const schema = Joi.string().valid('foo');
   // Need a real Joi error to use in a few places for these tests
-  const result = Joi.string().valid('foo').validate(null);
+  const result = schema.validate(null);
   describe.each`
     value
     ${null}
     ${undefined}
     ${Error()}
+    ${{}}
     `('format($value)', ({ value }) => {
   it('throws an error', () => {
     expect.assertions(1);
@@ -430,18 +433,24 @@ describe('format()', () => {
 });
   it('throws an error if the source is not a valid string', () => {
     expect.assertions(1);
-    expect(() => format(result, 'foo')).toThrow();
+    expect(() => format(result.error, 'foo')).toThrow();
   });
   it('throws an error if the option arguments is incorrect', () => {
     expect.assertions(1);
-    expect(() => format(result, 'body', false)).toThrow();
-  });
-  it('returns a formatted error object without options', () => {
-    expect.assertions(1);
-    expect(format(result, 'body')).toMatchSnapshot();
+    expect(() => format(result.error, 'body', false)).toThrow();
   });
   it('returns a formatted error object with options', () => {
     expect.assertions(1);
-    expect(format(result, 'body', { celebrated: true })).toMatchSnapshot();
+    expect(format(result.error, 'body', { celebrated: true })).toMatchSnapshot();
+  });
+  it('[sync] returns a formatted error object without options', () => {
+    expect.assertions(1);
+    expect(format(result.error, 'body')).toMatchSnapshot();
+  });
+  it('[async] returns a formatted error object without options', () => {
+    expect.assertions(1);
+    return schema.validateAsync(null).catch((e) => {
+      expect(format(e, 'body')).toMatchSnapshot();
+    });
   });
 });

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -10,6 +10,7 @@ const Teamwork = require('@hapi/teamwork');
 const {
   celebrate,
   Joi,
+  Segments,
 } = require('../lib');
 
 const Server = () => {
@@ -29,7 +30,7 @@ describe('validations', () => {
     const next = jest.fn();
 
     server.get('/', celebrate({
-      headers: {
+      [Segments.HEADERS]: {
         accept: Joi.string().regex(/xml/),
       },
     }, {
@@ -39,7 +40,7 @@ describe('validations', () => {
     server.inject({
       method: 'GET',
       url: '/',
-      headers: {
+      [Segments.HEADERS]: {
         accept: 'application/json',
       },
     }, team.attend.bind(team));
@@ -57,7 +58,7 @@ describe('validations', () => {
     const next = jest.fn();
 
     server.get('/user/:id', celebrate({
-      params: {
+      [Segments.PARAMS]: {
         id: Joi.string().token(),
       },
     }), next);
@@ -80,7 +81,7 @@ describe('validations', () => {
     const next = jest.fn();
 
     server.get('/', celebrate({
-      query: Joi.object().keys({
+      [Segments.QUERY]: Joi.object().keys({
         start: Joi.date(),
       }),
     }), next);
@@ -110,7 +111,7 @@ describe('validations', () => {
     server.inject({
       url: '/',
       method: 'post',
-      headers: {
+      [Segments.HEADERS]: {
         Cookie: 'state=notanumber',
       },
     }, team.attend.bind(team));
@@ -128,7 +129,7 @@ describe('validations', () => {
     const next = jest.fn();
 
     server.get('/', celebrate({
-      signedCookies: {
+      [Segments.SIGNEDCOOKIES]: {
         secureState: Joi.number().required(),
       },
     }), next);
@@ -138,7 +139,7 @@ describe('validations', () => {
     server.inject({
       url: '/',
       method: 'get',
-      headers: {
+      [Segments.HEADERS]: {
         Cookie: `state=s:${val}`,
       },
     }, team.attend.bind(team));
@@ -156,7 +157,7 @@ describe('validations', () => {
     const next = jest.fn();
 
     server.post('/', celebrate({
-      body: {
+      [Segments.BODY]: {
         first: Joi.string().required(),
         last: Joi.string(),
         role: Joi.number().integer(),
@@ -186,7 +187,7 @@ describe('update req values', () => {
     const team = new Teamwork();
 
     server.get('/', celebrate({
-      headers: {
+      [Segments.HEADERS]: {
         accept: Joi.string().regex(/json/),
         'secret-header': Joi.string().default('@@@@@@'),
       },
@@ -200,7 +201,7 @@ describe('update req values', () => {
     server.inject({
       method: 'GET',
       url: '/',
-      headers: {
+      [Segments.HEADERS]: {
         accept: 'application/json',
       },
     });
@@ -220,7 +221,7 @@ describe('update req values', () => {
     const team = new Teamwork();
 
     server.get('/user/:id', celebrate({
-      params: {
+      [Segments.PARAMS]: {
         id: Joi.string().uppercase(),
       },
     }), team.attend.bind(team));
@@ -241,7 +242,7 @@ describe('update req values', () => {
     const team = new Teamwork();
 
     server.get('/', celebrate({
-      query: Joi.object().keys({
+      [Segments.QUERY]: Joi.object().keys({
         name: Joi.string().uppercase(),
         page: Joi.number().default(1),
       }),
@@ -266,7 +267,7 @@ describe('update req values', () => {
     const team = new Teamwork();
 
     server.post('/', celebrate({
-      body: {
+      [Segments.BODY]: {
         first: Joi.string().required(),
         last: Joi.string().default('Smith'),
         role: Joi.string().uppercase(),
@@ -298,10 +299,10 @@ describe('reqContext', () => {
     const team = new Teamwork({ meetings: 2 });
 
     server.post('/:userId', celebrate({
-      body: {
+      [Segments.BODY]: {
         id: Joi.number().valid(Joi.ref('$params.userId')),
       },
-      params: {
+      [Segments.PARAMS]: {
         userId: Joi.number().integer().required(),
       },
     }, null, {
@@ -331,10 +332,10 @@ describe('reqContext', () => {
     const next = jest.fn();
 
     server.post('/:userId', celebrate({
-      body: {
+      [Segments.BODY]: {
         id: Joi.number().valid(Joi.ref('$params.userId')),
       },
-      params: {
+      [Segments.PARAMS]: {
         userId: Joi.number().integer().required(),
       },
     }, null, {


### PR DESCRIPTION
Closes #139

Change the arguments to format() to accomodate both sync and async validations.
Also exposed `Segments` enum to help consumers and docs.