### PR TITLE
Use CelebrateError object instead of POJO

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,10 +127,7 @@ Returns a `function` with the error handler signature (`(err, req, res, next)`).
 
 If the error format does not suite your needs, you are encouraged to write your own and check `isCelebrate(err)` to format celebrate errors to your liking. 
 
-Errors origintating from `celebrate()` are objects with the following keys:
-- `joi` - The full [joi error object](https://github.com/hapijs/joi/blob/master/API.md#errors).
-- `meta` - On `object` with the following keys:
-  - `source` - A [`Segments`](#segments) indicating the step where the validation failed.
+Errors origintating from `celebrate()` are [`CelebrateError`](#celebrateerrorerr-segment-opts)) objects.
 
 ### `Joi`
 
@@ -151,28 +148,27 @@ An enum containing all the segments of `req` objects that celebrate *can* valiat
 }
 ```
 
-### `isCelebrate(err)`
-
-Returns `true` if the provided `err` object originated from the `celebrate` middleware, and `false` otherwise. Useful if you want to write your own error handler for celebrate errors.
-
-- `err` - an error object
-
-### `format(err, segment, [opts])`
-
-Formats the incomming values into the shape of celebrate [errors](#errors())
+### `CelebrateError(err, segment, [opts])`
+Creates a new `CelebrateError` similar to the ones `celebrate` generates.
 
 - `err` - a Joi validation error object
-- `source` - A [`Segment`](#segments) indicating the step where the validation failed.
+- `segment` - A [`Segment`](#segments) indicating the step where the validation failed.
 - `[opts]` - optional `object` with the following keys
-  - `celebrated` -  `bool` that, when `true`, adds `Symbol('celebrated'): true` to the result object. This indicates this error as originating from `celebrate`. You'd likely want to set this to `true` if you want the celebrate error handler to handle errors originating from the `format` function that you call in user-land code. Defaults to `false`. 
+  - `celebrated` - `bool` that, when `true`, adds `Symbol('celebrated'): true` to the result object. This indicates this error as originating from `celebrate`. You'd likely want to set this to `true` if you want the celebrate error handler to handle errors originating from the `format` function that you call in user-land code. Defaults to `false`. 
 <details>
   <summary>Sample usage</summary>
 
   ```js
     const result = Joi.validate(req.params.id, Joi.string().valid('foo'), { abortEarly: false });
-    const err = format(result.error, Segments.PARAMS);
+    const err = CelebrateError(result.error, Segments.PARAMS);
   ```
 </details>
+
+### `isCelebrate(err)`
+
+Returns `true` if the provided `err` object originated from the `celebrate` middleware, and `false` otherwise. Useful if you want to write your own error handler for celebrate errors.
+
+- `err` - an error object
 
 ## Validation Order
 

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -6,16 +6,16 @@ import {
     ValidationResult 
 } from '@hapi/joi';
 
-enum Segments {
-    PARAMS="params",
-    HEADERS="headers",
-    QUERY="query",
-    COOKIES="cookies",
-    SIGNEDCOOKIES="signedCookies",
-    BODY="body"
-}
 
 declare namespace Celebrate {
+    declare enum Segments {
+        PARAMS="params",
+        HEADERS="headers",
+        QUERY="query",
+        COOKIES="cookies",
+        SIGNEDCOOKIES="signedCookies",
+        BODY="body"
+    }
     /**
     * Creates a Celebrate middleware function.
     */
@@ -67,20 +67,11 @@ declare namespace Celebrate {
     function isCelebrate(err: object): boolean;
 
     /**
-     * Format a joi error into a standard object
+     * The standard error used by Celebrate
      */
-    function format(err: ValidationError, 
-        source: Segment,
-        opts?: { celebrated: boolean }): {
-        meta: {
-            source: Segment
-        },
-        joi: ValidationError,
-    };
-    /**
-     * The different segments of req celebrate can valiate against
-     */
-    export const Segments: Segments;
+    declare class CelebrateError {
+        constructor(error: ValidationError, segment: Segments, opts?: { celebrated: boolean }) {}
+    }
 }
 
 export = Celebrate;

--- a/lib/index.js
+++ b/lib/index.js
@@ -16,11 +16,14 @@ const internals = {
   },
 };
 
-internals.format = (error, segment, opts) => ({
-  [internals.CELEBRATED]: opts.celebrated,
-  joi: error,
-  meta: { source: segment },
-});
+internals.CelebrateError = class extends Error {
+  constructor(joiError, segment, opts) {
+    super(joiError.message);
+    this.joi = joiError;
+    this.meta = { source: segment };
+    this[internals.CELEBRATED] = opts.celebrated;
+  }
+};
 
 internals.validateSource = (segment, spec) => ({
   config,
@@ -31,7 +34,11 @@ internals.validateSource = (segment, spec) => ({
       value,
       segment,
     });
-  }).catch((e) => reject(internals.format(e, segment, internals.DEFAULT_FORMAT_OPTIONS)));
+  }).catch((e) => reject(new internals.CelebrateError(
+    e,
+    segment,
+    internals.DEFAULT_FORMAT_OPTIONS,
+  )));
 });
 
 internals.maybeValidateBody = (segment, spec) => (opts) => {
@@ -151,7 +158,7 @@ exports.errors = () => (err, req, res, next) => {
   return res.status(400).send(result);
 };
 
-exports.format = (error, segment, opts = { celebrated: false }) => {
+exports.CelebrateError = (error, segment, opts = { celebrated: false }) => {
   Assert.ok(error.isJoi);
 
   let result = sourceSchema.validate(segment);
@@ -159,7 +166,7 @@ exports.format = (error, segment, opts = { celebrated: false }) => {
   result = optSchema.validate(opts);
   Assert.ifError(result.error);
 
-  return internals.format(error, segment, opts);
+  return new internals.CelebrateError(error, segment, opts);
 };
 
 exports.Joi = Joi;

--- a/test/__snapshots__/celebrate.test.js.snap
+++ b/test/__snapshots__/celebrate.test.js.snap
@@ -40,33 +40,3 @@ Object {
   },
 }
 `;
-
-exports[`format() [async] returns a formatted error object without options 1`] = `
-Object {
-  "joi": [ValidationError: "value" must be [foo]],
-  "meta": Object {
-    "source": "body",
-  },
-  Symbol(celebrated): false,
-}
-`;
-
-exports[`format() [sync] returns a formatted error object without options 1`] = `
-Object {
-  "joi": [ValidationError: "value" must be [foo]],
-  "meta": Object {
-    "source": "body",
-  },
-  Symbol(celebrated): false,
-}
-`;
-
-exports[`format() returns a formatted error object with options 1`] = `
-Object {
-  "joi": [ValidationError: "value" must be [foo]],
-  "meta": Object {
-    "source": "body",
-  },
-  Symbol(celebrated): true,
-}
-`;


### PR DESCRIPTION
Closes #138

We now use error objects that extend the base `Error` object. Removed
`format` in favor of calling `CelebrateError()` directly. This way we
are always using "real" Error objects. This can be handy for things
outside of this library that want all Error objects to extend the
built in one.