### PR TITLE
Fix declare issues

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -8,7 +8,7 @@ import {
 
 
 declare namespace Celebrate {
-    declare enum Segments {
+    enum Segments {
         PARAMS="params",
         HEADERS="headers",
         QUERY="query",
@@ -69,8 +69,8 @@ declare namespace Celebrate {
     /**
      * The standard error used by Celebrate
      */
-    declare class CelebrateError {
-        constructor(error: ValidationError, segment: Segments, opts?: { celebrated: boolean }) {}
+    class CelebrateError {
+        constructor(error: ValidationError, segment: Segments, opts?: { celebrated: boolean })
     }
 }
 


### PR DESCRIPTION
Fixes #149 

Removed false declare modifiers in the typescript declaration file. This is only important for v11 as this issue doesn't exist in v10 or at least I had no problems with it. 

Is there anything else that change because of the v11 Update. Error changed, so the CelebrateError class in the index.d.ts might not be important anymore. I would need to know how errors exactly work now.

I'll open this as a draft to make some changes if changes need to be done. 