### PR TITLE
New Internals

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,8 +117,8 @@ celebrate does not have a default export. The following methods encompass the pu
 
 Returns a `function` with the middleware signature (`(req, res, next)`).
 
-- `schema` - an `object` where `key` can be one of the values from [`Segments`](#segments) and the `value` is a [joi](https://github.com/hapijs/joi/blob/master/API.md) validation schema. Only the keys specified will be validated against the incoming request object. If you omit a key, that part of the `req` object will not be validated. A schema must contain at least one valid key. 
-- `[joiOptions]` - optional `object` containing joi [options](https://github.com/hapijs/joi/blob/master/API.md#anyvalidatevalue-options) that are passed directly into the `validate` function. Defaults to `{ warnings: true }`.
+- `requestRules` - an `object` where `key` can be one of the values from [`Segments`](#segments) and the `value` is a [joi](https://github.com/hapijs/joi/blob/master/API.md) validation schema. Only the keys specified will be validated against the incoming request object. If you omit a key, that part of the `req` object will not be validated. A schema must contain at least one valid key. 
+- `[joiOpts]` - optional `object` containing joi [options](https://github.com/hapijs/joi/blob/master/API.md#anyvalidatevalue-options) that are passed directly into the `validate` function. Defaults to `{ warnings: true }`.
 - `[opts]` - an optional `object` with the following keys. Defaults to `{}`.
   - `reqContext` - `bool` value that instructs joi to use the incoming `req` object as the `context` value during joi validation. If set, this will trump the value of `joiOptions.context`. This is useful if you want to validate part of the request object against another part of the request object. See the tests for more details.
 
@@ -149,7 +149,7 @@ An enum containing all the segments of `req` objects that celebrate *can* valiat
 }
 ```
 
-### `CelebrateError(err, segment, [opts])`
+### `CelebrateError(error, segment, [opts])`
 
 A factory function for creating celebrate errors.
 

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -60,7 +60,7 @@ export interface SchemaOptions {
 /**
 * Creates a Celebrate middleware function.
 */
-export declare function celebrate(schema: SchemaOptions, joiOptions?: ValidationOptions, opts?: CelebrateOptions): RequestHandler;
+export declare function celebrate(requestRules: SchemaOptions, joiOpts?: ValidationOptions, opts?: CelebrateOptions): RequestHandler;
 
 /**
  * Creates a Celebrate error handler middleware function.

--- a/lib/index.js
+++ b/lib/index.js
@@ -56,32 +56,55 @@ internals.maybeValidateBody = (segment, spec) => (opts) => {
 
 // Map of segments to validation functions.
 // The key order is the order validations will run in.
-internals.REQ_VALIDATIONS = new Map([
-  [segments.HEADERS, internals.validateSource],
-  [segments.PARAMS, internals.validateSource],
-  [segments.QUERY, internals.validateSource],
-  [segments.COOKIES, internals.validateSource],
-  [segments.SIGNEDCOOKIES, internals.validateSource],
-  [segments.BODY, internals.maybeValidateBody],
-]);
+// internals.REQ_VALIDATIONS = new Map([
+//   [segments.HEADERS, internals.validateSource],
+//   [segments.PARAMS, internals.validateSource],
+//   [segments.QUERY, internals.validateSource],
+//   [segments.COOKIES, internals.validateSource],
+//   [segments.SIGNEDCOOKIES, internals.validateSource],
+//   [segments.BODY, internals.maybeValidateBody],
+// ]);
+internals.REQ_VALIDATIONS = [
+  {
+    segment: segments.HEADERS,
+    fn: internals.validateSource,
+  }, {
+    segment: segments.PARAMS,
+    fn: internals.validateSource,
+  },
+  {
+    segment: segments.QUERY,
+    fn: internals.validateSource,
+  },
+  {
+    segment: segments.COOKIES,
+    fn: internals.validateSource,
+  },
+  {
+    segment: segments.SIGNEDCOOKIES,
+    fn: internals.validateSource,
+  },
+  {
+    segment: segments.BODY,
+    fn: internals.maybeValidateBody,
+  },
+];
 
 // ⚠️ steps is mutated in this function
-internals.check = (steps, opts) => {
-  const validateFn = steps.shift();
-  if (validateFn) {
-    return validateFn(opts).then(({ value, segment }) => {
+internals.check = (steps, opts) => steps.reduce((chain, step) => chain.then(() => {
+  const schema = opts.schema[step.segment];
+  if (schema) {
+    return step.fn(step.segment, Joi.compile(schema))(opts).then(({ value, segment }) => {
       if (value != null) {
         Object.defineProperty(opts.req, segment, {
           value,
         });
       }
-      return internals.check(steps, opts);
+      return null;
     });
   }
-  // If we get here, all the promises have resolved
-  // and so we have a final resolve to end the recursion
   return Promise.resolve(null);
-};
+}), Promise.resolve(null));
 
 exports.celebrate = (schema, joiOpts = {}, opts = {}) => {
   Joi.assert(schema, middlewareSchema);
@@ -89,13 +112,13 @@ exports.celebrate = (schema, joiOpts = {}, opts = {}) => {
 
   const middleware = (req, res, next) => {
     // We want a fresh copy of steps since `internals.check` mutates the array
-    const steps = [];
-    internals.REQ_VALIDATIONS.forEach((validateFn, segment) => {
-      const spec = schema[segment];
-      if (spec) {
-        steps.push(validateFn(segment, Joi.compile(spec)));
-      }
-    });
+    // const steps = [];
+    // internals.REQ_VALIDATIONS.forEach((validateFn, segment) => {
+    //   const spec = schema[segment];
+    //   if (spec) {
+    //     steps.push(validateFn(segment, Joi.compile(spec)));
+    //   }
+    // });
 
     const finalConfig = opts.reqContext ? {
       ...joiOpts,
@@ -106,9 +129,10 @@ exports.celebrate = (schema, joiOpts = {}, opts = {}) => {
       warnings: true,
     };
 
-    return internals.check(steps, {
+    return internals.check(internals.REQ_VALIDATIONS, {
       config: finalConfig,
       req,
+      schema,
     })
       .then(next)
       .catch(next);

--- a/lib/index.js
+++ b/lib/index.js
@@ -2,10 +2,10 @@ const Assert = require('assert');
 const Joi = require('@hapi/joi');
 const EscapeHtml = require('escape-html');
 const {
-  celebrateErrorOptsSchema,
-  celebrateOptsSchema,
-  requestSchema,
-  segmentSchema,
+  CELEBRATEERROROPTSSCHEMA,
+  CELEBRATEOPTSSCHEMA,
+  REQUESTSCHEMA,
+  SEGMENTSCHEMA,
 } = require('./schema');
 const { segments } = require('./constants');
 
@@ -73,34 +73,42 @@ internals.REQ_VALIDATIONS = [
 ];
 
 internals.check = (steps, requestRules, opts) => steps.reduce((chain, {
-  validate,
-  segment,
+  validate: stepValidate,
+  segment: stepSegment,
 }) => chain.then(() => {
-  const segmentRule = requestRules[segment];
-  if (segmentRule) {
-    return validate(Joi.compile(segmentRule), opts)
-      .then(({ value }) => {
-        if (value != null) {
-          Object.defineProperty(opts.req, segment, {
-            value,
-          });
-        }
-        return null;
-      })
-      .catch((e) => {
-        throw new internals.CelebrateError(
-          e,
-          segment,
-          internals.DEFAULT_ERROR_ARGS,
-        );
-      });
+  // If there isn't a schema set up for this segment, early return
+  const currentSegmentSchema = requestRules.get(stepSegment);
+  if (!currentSegmentSchema) {
+    return Promise.resolve(null);
   }
-  return Promise.resolve(null);
+
+  return stepValidate(currentSegmentSchema, opts)
+    .then(({ value }) => {
+      if (value != null) {
+        Object.defineProperty(opts.req, stepSegment, {
+          value,
+        });
+      }
+      return null;
+    })
+    .catch((e) => {
+      throw new internals.CelebrateError(
+        e,
+        stepSegment,
+        internals.DEFAULT_ERROR_ARGS,
+      );
+    });
 }), Promise.resolve(null));
 
-exports.celebrate = (requestRules, joiOpts = {}, opts = {}) => {
-  Joi.assert(requestRules, requestSchema);
-  Joi.assert(opts, celebrateOptsSchema);
+exports.celebrate = (_requestRules, joiOpts = {}, opts = {}) => {
+  Joi.assert(_requestRules, REQUESTSCHEMA);
+  Joi.assert(opts, CELEBRATEOPTSSCHEMA);
+
+  // Compile all schemas in advance and only do it once
+  const requestRules = Object.entries(_requestRules).reduce((memo, [key, value]) => {
+    memo.set(key, Joi.compile(value));
+    return memo;
+  }, new Map());
 
   const middleware = (req, res, next) => {
     const finalConfig = opts.reqContext ? {
@@ -112,6 +120,7 @@ exports.celebrate = (requestRules, joiOpts = {}, opts = {}) => {
       warnings: true,
     };
 
+    // This promise is not part of the public API; it's only here to make the tests cleaner
     return internals.check(internals.REQ_VALIDATIONS, requestRules, {
       config: finalConfig,
       req,
@@ -162,8 +171,8 @@ exports.errors = () => (err, req, res, next) => {
 
 exports.CelebrateError = (error, segment, opts = { celebrated: false }) => {
   Assert.ok(error && error.isJoi, '"error" must be a Joi error');
-  Joi.assert(segment, segmentSchema);
-  Joi.assert(opts, celebrateErrorOptsSchema);
+  Joi.assert(segment, SEGMENTSCHEMA);
+  Joi.assert(opts, CELEBRATEERROROPTSSCHEMA);
   return new internals.CelebrateError(error, segment, opts);
 };
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -28,17 +28,7 @@ internals.CelebrateError = class extends Error {
 internals.validateSegment = (segment) => (spec, {
   config,
   req,
-}) => new Promise((resolve, reject) => {
-  spec.validateAsync(req[segment], config).then(({ value }) => {
-    resolve({
-      value,
-    });
-  }).catch((e) => reject(new internals.CelebrateError(
-    e,
-    segment,
-    internals.DEFAULT_ERROR_ARGS,
-  )));
-});
+}) => spec.validateAsync(req[segment], config);
 
 internals.maybeValidateBody = (segment) => {
   const validateBody = internals.validateSegment(segment);
@@ -48,7 +38,6 @@ internals.maybeValidateBody = (segment) => {
     if (method === 'get' || method === 'head') {
       return Promise.resolve({
         value: null,
-        segment,
       });
     }
 
@@ -89,14 +78,22 @@ internals.check = (steps, requestRules, opts) => steps.reduce((chain, {
 }) => chain.then(() => {
   const segmentRule = requestRules[segment];
   if (segmentRule) {
-    return validate(Joi.compile(segmentRule), opts).then(({ value }) => {
-      if (value != null) {
-        Object.defineProperty(opts.req, segment, {
-          value,
-        });
-      }
-      return null;
-    });
+    return validate(Joi.compile(segmentRule), opts)
+      .then(({ value }) => {
+        if (value != null) {
+          Object.defineProperty(opts.req, segment, {
+            value,
+          });
+        }
+        return null;
+      })
+      .catch((e) => {
+        throw new internals.CelebrateError(
+          e,
+          segment,
+          internals.DEFAULT_ERROR_ARGS,
+        );
+      });
   }
   return Promise.resolve(null);
 }), Promise.resolve(null));
@@ -118,9 +115,7 @@ exports.celebrate = (requestRules, joiOpts = {}, opts = {}) => {
     return internals.check(internals.REQ_VALIDATIONS, requestRules, {
       config: finalConfig,
       req,
-    })
-      .then(next)
-      .catch(next);
+    }).then(next).catch(next);
   };
 
   middleware._schema = requestRules;

--- a/lib/index.js
+++ b/lib/index.js
@@ -25,7 +25,7 @@ internals.CelebrateError = class extends Error {
   }
 };
 
-internals.validateSource = (segment, spec) => ({
+internals.validateSegment = (segment) => (spec, {
   config,
   req,
 }) => new Promise((resolve, reject) => {
@@ -41,60 +41,52 @@ internals.validateSource = (segment, spec) => ({
   )));
 });
 
-internals.maybeValidateBody = (segment, spec) => (opts) => {
-  const method = opts.req.method.toLowerCase();
+internals.maybeValidateBody = (segment) => {
+  const validateBody = internals.validateSegment(segment);
+  return (spec, opts) => {
+    const method = opts.req.method.toLowerCase();
 
-  if (method === 'get' || method === 'head') {
-    return Promise.resolve({
-      value: null,
-      segment,
-    });
-  }
+    if (method === 'get' || method === 'head') {
+      return Promise.resolve({
+        value: null,
+        segment,
+      });
+    }
 
-  return internals.validateSource(segment, spec)(opts);
+    return validateBody(spec, opts);
+  };
 };
 
-// Map of segments to validation functions.
-// The key order is the order validations will run in.
-// internals.REQ_VALIDATIONS = new Map([
-//   [segments.HEADERS, internals.validateSource],
-//   [segments.PARAMS, internals.validateSource],
-//   [segments.QUERY, internals.validateSource],
-//   [segments.COOKIES, internals.validateSource],
-//   [segments.SIGNEDCOOKIES, internals.validateSource],
-//   [segments.BODY, internals.maybeValidateBody],
-// ]);
 internals.REQ_VALIDATIONS = [
   {
     segment: segments.HEADERS,
-    fn: internals.validateSource,
+    fn: internals.validateSegment(segments.HEADERS),
   }, {
     segment: segments.PARAMS,
-    fn: internals.validateSource,
+    fn: internals.validateSegment(segments.PARAMS),
   },
   {
     segment: segments.QUERY,
-    fn: internals.validateSource,
+    fn: internals.validateSegment(segments.QUERY),
   },
   {
     segment: segments.COOKIES,
-    fn: internals.validateSource,
+    fn: internals.validateSegment(segments.COOKIES),
   },
   {
     segment: segments.SIGNEDCOOKIES,
-    fn: internals.validateSource,
+    fn: internals.validateSegment(segments.SIGNEDCOOKIES),
   },
   {
     segment: segments.BODY,
-    fn: internals.maybeValidateBody,
+    fn: internals.maybeValidateBody(segments.BODY),
   },
 ];
 
-// ⚠️ steps is mutated in this function
-internals.check = (steps, opts) => steps.reduce((chain, step) => chain.then(() => {
-  const schema = opts.schema[step.segment];
-  if (schema) {
-    return step.fn(step.segment, Joi.compile(schema))(opts).then(({ value, segment }) => {
+internals.check = (steps, requestSchema, opts) => steps.reduce((chain, step) => chain.then(() => {
+  const segmentSchema = requestSchema[step.segment];
+  if (segmentSchema) {
+    return step.fn(Joi.compile(segmentSchema), opts).then(({ value, segment }) => {
       if (value != null) {
         Object.defineProperty(opts.req, segment, {
           value,
@@ -106,20 +98,11 @@ internals.check = (steps, opts) => steps.reduce((chain, step) => chain.then(() =
   return Promise.resolve(null);
 }), Promise.resolve(null));
 
-exports.celebrate = (schema, joiOpts = {}, opts = {}) => {
-  Joi.assert(schema, middlewareSchema);
+exports.celebrate = (requestSchema, joiOpts = {}, opts = {}) => {
+  Joi.assert(requestSchema, middlewareSchema);
   Joi.assert(opts, celebrateSchema);
 
   const middleware = (req, res, next) => {
-    // We want a fresh copy of steps since `internals.check` mutates the array
-    // const steps = [];
-    // internals.REQ_VALIDATIONS.forEach((validateFn, segment) => {
-    //   const spec = schema[segment];
-    //   if (spec) {
-    //     steps.push(validateFn(segment, Joi.compile(spec)));
-    //   }
-    // });
-
     const finalConfig = opts.reqContext ? {
       ...joiOpts,
       context: req,
@@ -129,16 +112,15 @@ exports.celebrate = (schema, joiOpts = {}, opts = {}) => {
       warnings: true,
     };
 
-    return internals.check(internals.REQ_VALIDATIONS, {
+    return internals.check(internals.REQ_VALIDATIONS, requestSchema, {
       config: finalConfig,
       req,
-      schema,
     })
       .then(next)
       .catch(next);
   };
 
-  middleware._schema = schema;
+  middleware._schema = requestSchema;
 
   return middleware;
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -2,10 +2,10 @@ const Assert = require('assert');
 const Joi = require('@hapi/joi');
 const EscapeHtml = require('escape-html');
 const {
-  middlewareSchema,
-  celebrateSchema,
-  sourceSchema,
-  optSchema,
+  celebrateErrorOptsSchema,
+  celebrateOptsSchema,
+  requestSchema,
+  segmentSchema,
 } = require('./schema');
 const { segments } = require('./constants');
 
@@ -32,7 +32,6 @@ internals.validateSegment = (segment) => (spec, {
   spec.validateAsync(req[segment], config).then(({ value }) => {
     resolve({
       value,
-      segment,
     });
   }).catch((e) => reject(new internals.CelebrateError(
     e,
@@ -60,33 +59,37 @@ internals.maybeValidateBody = (segment) => {
 internals.REQ_VALIDATIONS = [
   {
     segment: segments.HEADERS,
-    fn: internals.validateSegment(segments.HEADERS),
-  }, {
+    validate: internals.validateSegment(segments.HEADERS),
+  },
+  {
     segment: segments.PARAMS,
-    fn: internals.validateSegment(segments.PARAMS),
+    validate: internals.validateSegment(segments.PARAMS),
   },
   {
     segment: segments.QUERY,
-    fn: internals.validateSegment(segments.QUERY),
+    validate: internals.validateSegment(segments.QUERY),
   },
   {
     segment: segments.COOKIES,
-    fn: internals.validateSegment(segments.COOKIES),
+    validate: internals.validateSegment(segments.COOKIES),
   },
   {
     segment: segments.SIGNEDCOOKIES,
-    fn: internals.validateSegment(segments.SIGNEDCOOKIES),
+    validate: internals.validateSegment(segments.SIGNEDCOOKIES),
   },
   {
     segment: segments.BODY,
-    fn: internals.maybeValidateBody(segments.BODY),
+    validate: internals.maybeValidateBody(segments.BODY),
   },
 ];
 
-internals.check = (steps, requestSchema, opts) => steps.reduce((chain, step) => chain.then(() => {
-  const segmentSchema = requestSchema[step.segment];
-  if (segmentSchema) {
-    return step.fn(Joi.compile(segmentSchema), opts).then(({ value, segment }) => {
+internals.check = (steps, requestRules, opts) => steps.reduce((chain, {
+  validate,
+  segment,
+}) => chain.then(() => {
+  const segmentRule = requestRules[segment];
+  if (segmentRule) {
+    return validate(Joi.compile(segmentRule), opts).then(({ value }) => {
       if (value != null) {
         Object.defineProperty(opts.req, segment, {
           value,
@@ -98,9 +101,9 @@ internals.check = (steps, requestSchema, opts) => steps.reduce((chain, step) => 
   return Promise.resolve(null);
 }), Promise.resolve(null));
 
-exports.celebrate = (requestSchema, joiOpts = {}, opts = {}) => {
-  Joi.assert(requestSchema, middlewareSchema);
-  Joi.assert(opts, celebrateSchema);
+exports.celebrate = (requestRules, joiOpts = {}, opts = {}) => {
+  Joi.assert(requestRules, requestSchema);
+  Joi.assert(opts, celebrateOptsSchema);
 
   const middleware = (req, res, next) => {
     const finalConfig = opts.reqContext ? {
@@ -112,7 +115,7 @@ exports.celebrate = (requestSchema, joiOpts = {}, opts = {}) => {
       warnings: true,
     };
 
-    return internals.check(internals.REQ_VALIDATIONS, requestSchema, {
+    return internals.check(internals.REQ_VALIDATIONS, requestRules, {
       config: finalConfig,
       req,
     })
@@ -120,7 +123,7 @@ exports.celebrate = (requestSchema, joiOpts = {}, opts = {}) => {
       .catch(next);
   };
 
-  middleware._schema = requestSchema;
+  middleware._schema = requestRules;
 
   return middleware;
 };
@@ -164,8 +167,8 @@ exports.errors = () => (err, req, res, next) => {
 
 exports.CelebrateError = (error, segment, opts = { celebrated: false }) => {
   Assert.ok(error && error.isJoi, '"error" must be a Joi error');
-  Joi.assert(segment, sourceSchema);
-  Joi.assert(opts, optSchema);
+  Joi.assert(segment, segmentSchema);
+  Joi.assert(opts, celebrateErrorOptsSchema);
   return new internals.CelebrateError(error, segment, opts);
 };
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -36,6 +36,8 @@ internals.maybeValidateBody = (segment) => {
     const method = opts.req.method.toLowerCase();
 
     if (method === 'get' || method === 'head') {
+      // This resolve is to emulate how Joi validates when there isn't an error. I'm doing this to
+      // standardize the resolve value.
       return Promise.resolve({
         value: null,
       });
@@ -72,6 +74,7 @@ internals.REQ_VALIDATIONS = [
   },
 ];
 
+// Lifted this idea from https://bit.ly/2vf3Xe0
 internals.check = (steps, requestRules, opts) => steps.reduce((chain, {
   validate: stepValidate,
   segment: stepSegment,
@@ -105,13 +108,11 @@ exports.celebrate = (_requestRules, joiOpts = {}, opts = {}) => {
   Joi.assert(opts, CELEBRATEOPTSSCHEMA);
 
   // Compile all schemas in advance and only do it once
-  const requestRules = Object.entries(_requestRules).reduce((memo, [key, value]) => {
-    memo.set(key, Joi.compile(value));
-    return memo;
-  }, new Map());
+  const requestRules = Object.entries(_requestRules)
+    .reduce((memo, [key, value]) => memo.set(key, Joi.compile(value)), new Map());
 
   const middleware = (req, res, next) => {
-    const finalConfig = opts.reqContext ? {
+    const config = opts.reqContext ? {
       ...joiOpts,
       context: req,
       warnings: true,
@@ -122,12 +123,12 @@ exports.celebrate = (_requestRules, joiOpts = {}, opts = {}) => {
 
     // This promise is not part of the public API; it's only here to make the tests cleaner
     return internals.check(internals.REQ_VALIDATIONS, requestRules, {
-      config: finalConfig,
+      config,
       req,
     }).then(next).catch(next);
   };
 
-  middleware._schema = requestRules;
+  middleware._schema = _requestRules;
 
   return middleware;
 };

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -1,7 +1,7 @@
 const Joi = require('@hapi/joi');
 const { segments } = require('./constants');
 
-exports.requestSchema = Joi.object({
+exports.REQUESTSCHEMA = Joi.object({
   [segments.HEADERS]: Joi.any(),
   [segments.PARAMS]: Joi.any(),
   [segments.QUERY]: Joi.any(),
@@ -10,11 +10,11 @@ exports.requestSchema = Joi.object({
   [segments.BODY]: Joi.any(),
 }).required().min(1);
 
-exports.celebrateOptsSchema = Joi.object({
+exports.CELEBRATEOPTSSCHEMA = Joi.object({
   reqContext: Joi.boolean(),
 });
 
-exports.segmentSchema = Joi.string().valid(
+exports.SEGMENTSCHEMA = Joi.string().valid(
   segments.HEADERS,
   segments.PARAMS,
   segments.QUERY,
@@ -23,6 +23,6 @@ exports.segmentSchema = Joi.string().valid(
   segments.BODY,
 );
 
-exports.celebrateErrorOptsSchema = Joi.object({
+exports.CELEBRATEERROROPTSSCHEMA = Joi.object({
   celebrated: Joi.boolean().default(false),
 });

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -1,7 +1,7 @@
 const Joi = require('@hapi/joi');
 const { segments } = require('./constants');
 
-exports.middlewareSchema = Joi.object({
+exports.requestSchema = Joi.object({
   [segments.HEADERS]: Joi.any(),
   [segments.PARAMS]: Joi.any(),
   [segments.QUERY]: Joi.any(),
@@ -10,11 +10,11 @@ exports.middlewareSchema = Joi.object({
   [segments.BODY]: Joi.any(),
 }).required().min(1);
 
-exports.celebrateSchema = Joi.object({
+exports.celebrateOptsSchema = Joi.object({
   reqContext: Joi.boolean(),
 });
 
-exports.sourceSchema = Joi.string().valid(
+exports.segmentSchema = Joi.string().valid(
   segments.HEADERS,
   segments.PARAMS,
   segments.QUERY,
@@ -23,6 +23,6 @@ exports.sourceSchema = Joi.string().valid(
   segments.BODY,
 );
 
-exports.optSchema = Joi.object({
+exports.celebrateErrorOptsSchema = Joi.object({
   celebrated: Joi.boolean().default(false),
 });

--- a/test/celebrate.test.js
+++ b/test/celebrate.test.js
@@ -1,6 +1,8 @@
 /* eslint-env jest */
 const expect = require('expect');
-const { name, random, date } = require('faker');
+const {
+  name, random, date, internet,
+} = require('faker');
 const {
   celebrate,
   Joi,
@@ -86,12 +88,14 @@ describe('celebrate()', () => {
     const first = name.firstName();
     const last = name.lastName();
     const role = name.jobTitle();
+    const browser = internet.domainWord();
     const req = {
       [Segments.BODY]: {
         first,
         last,
       },
       [Segments.QUERY]: undefined,
+      [Segments.COOKIES]: { browser: undefined, agent: 'Node' },
       method: 'POST',
     };
     const middleware = celebrate({
@@ -101,6 +105,10 @@ describe('celebrate()', () => {
         role: Joi.number().integer().default(role),
       },
       [Segments.QUERY]: Joi.number(),
+      [Segments.COOKIES]: Joi.object().keys({
+        browser: Joi.string().default(browser),
+        agent: Joi.string().uppercase().required(),
+      }),
     });
 
     return middleware(req, null, (err) => {
@@ -111,6 +119,10 @@ describe('celebrate()', () => {
         role,
       });
       expect(req.query).toBeUndefined();
+      expect(req.cookies).toEqual({
+        browser,
+        agent: 'NODE',
+      });
     });
   });
 


### PR DESCRIPTION
After staring at the main validation path for a few hours, I realized a lot of this code is more complex than it really needed to be. 

## Biggest changes:
- Reuse the same array on every request. This way, I'm not creating single use arrays that need to be GCed after every run.
- Stop creating new promises on every validation and instead let Joi do this (I don't think's a real promise, but it behaves like one)
- Change `validateBody` to be a closure to keep a curried copy of `validateSegment` around so we only need to create this once.
- Changed the main validation path to use `[].reduce(() =>{}, Promise.resolve(null)` rather than the recursive way it used to be.
- Precompile all the schemas outside of the middleware so it only happens once per invocation of `celebrate()` not every time the request is validated

## Benchmarks

These values come from `node utils/benchmark`:

`pre-change`

> valid x 32,945 ops/sec ±5.60% (77 runs sampled)
> invalid x 23,976 ops/sec ±1.96% (85 runs sampled)
> 
> valid x 37,814 ops/sec ±1.73% (80 runs sampled)
> invalid x 24,608 ops/sec ±2.28% (85 runs sampled)
> 
> valid x 31,047 ops/sec ±8.14% (78 runs sampled)
> invalid x 24,413 ops/sec ±2.22% (82 runs sampled)

`after-change`

> valid x 350,009 ops/sec ±1.76% (73 runs sampled)
> invalid x 337,577 ops/sec ±4.04% (72 runs sampled)
> 
> valid x 343,469 ops/sec ±5.65% (27 runs sampled)
> invalid x 205,444 ops/sec ±4.48% (26 runs sampled)
> 
> valid x 385,833 ops/sec ±2.49% (53 runs sampled)
> invalid x 353,932 ops/sec ±6.53% (72 runs sampled)

Unless I'm doing something **incredibly** wrong, that's an order of magnitude faster 😮 