### PR TITLE
Error handler config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 sudo: false
 language: node_js
 node_js:
-    - "10"
     - "12"
     - "node"
 

--- a/README.md
+++ b/README.md
@@ -123,13 +123,16 @@ Returns a `function` with the middleware signature (`(req, res, next)`).
 - `[opts]` - an optional `object` with the following keys. Defaults to `{}`.
   - `reqContext` - `bool` value that instructs joi to use the incoming `req` object as the `context` value during joi validation. If set, this will trump the value of `joiOptions.context`. This is useful if you want to validate part of the request object against another part of the request object. See the tests for more details.
 
-### `errors()`
+### `errors([opts])`
 
-Returns a `function` with the error handler signature (`(err, req, res, next)`). This should be placed with any other error handling middleware to catch celebrate errors. If the incoming `err` object is an error originating from celebrate, `errors()` will respond with a 400 status code and the joi validation message. Otherwise, it will call `next(err)` and will pass the error along and will need to be processed by another error handler.
+Returns a `function` with the error handler signature (`(err, req, res, next)`). This should be placed with any other error handling middleware to catch celebrate errors. If the incoming `err` object is an error originating from celebrate, `errors()` will respond a pre-build error object. Otherwise, it will call `next(err)` and will pass the error along and will need to be processed by another error handler.
 
-If the error format does not suite your needs, you are encouraged to write your own and check `isCelebrate(err)` to format celebrate errors to your liking. 
+- `[opts]` - an optional `object` with the following keys
+  - `statusCode` - `number` that will be used for the response status code in the event of an error. Must be greater than 399 and less than 600. It must also be a number available to the node [HTTP module](https://nodejs.org/api/http.html#http_http_status_codes). Defaults to 400.
 
-Errors origintating from `celebrate()` are [`CelebrateError`](#celebrateerrorerr-segment-opts)) objects.
+If the error response format does not suite your needs, you are encouraged to write your own and check `isCelebrate(err)` to format celebrate errors to your liking. 
+
+Errors origintating from the `celebrate()` middleware are [`CelebrateError`](#celebrateerrorerr-segment-opts) objects.
 
 ### `Joi`
 

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -65,7 +65,7 @@ export declare function celebrate(requestRules: SchemaOptions, joiOpts?: Validat
 /**
  * Creates a Celebrate error handler middleware function.
  */
-export declare function errors(): ErrorRequestHandler;
+export declare function errors(opts?: { statusCode: number }): ErrorRequestHandler;
 
 /**
  * The Joi version Celebrate uses internally.

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,4 +1,5 @@
 const Assert = require('assert');
+const HTTP = require('http');
 const Joi = require('@hapi/joi');
 const EscapeHtml = require('escape-html');
 const {
@@ -6,6 +7,7 @@ const {
   CELEBRATEOPTSSCHEMA,
   REQUESTSCHEMA,
   SEGMENTSCHEMA,
+  ERRORSOPTSSCHEMA,
 } = require('./schema');
 const { segments } = require('./constants');
 
@@ -13,6 +15,9 @@ const internals = {
   CELEBRATED: Symbol('celebrated'),
   DEFAULT_ERROR_ARGS: {
     celebrated: true,
+  },
+  DEFAULT_ERRORS_OPTS: {
+    statusCode: 400,
   },
 };
 
@@ -135,39 +140,48 @@ exports.celebrate = (_requestRules, joiOpts = {}, opts = {}) => {
 
 exports.isCelebrate = (err) => {
   if (err != null && typeof err === 'object') {
-    return err[internals.CELEBRATED] || false;
+    return Boolean(err[internals.CELEBRATED]);
   }
   return false;
 };
 
-exports.errors = () => (err, req, res, next) => {
+exports.errors = (opts = {}) => {
+  const finalOpts = { ...internals.DEFAULT_ERRORS_OPTS, ...opts };
+  Joi.assert(finalOpts, ERRORSOPTSSCHEMA);
+
+  return (err, req, res, next) => {
   // If this isn't a Celebrate error, send it to the next error handler
-  if (!exports.isCelebrate(err)) {
-    return next(err);
-  }
-
-  const {
-    joi,
-    meta,
-  } = err;
-
-  const result = {
-    statusCode: 400,
-    error: 'Bad Request',
-    message: joi.message,
-    validation: {
-      source: meta.source,
-      keys: [],
-    },
-  };
-
-  if (joi.details) {
-    for (let i = 0; i < joi.details.length; i += 1) {
-      const path = joi.details[i].path.join('.');
-      result.validation.keys.push(EscapeHtml(path));
+    if (!exports.isCelebrate(err)) {
+      return next(err);
     }
-  }
-  return res.status(400).send(result);
+
+    const {
+      joi,
+      meta,
+    } = err;
+
+    const {
+      statusCode,
+    } = finalOpts;
+
+    const result = {
+      statusCode,
+      error: HTTP.STATUS_CODES[statusCode],
+      message: joi.message,
+      validation: {
+        source: meta.source,
+        keys: [],
+      },
+    };
+
+    if (joi.details) {
+      for (let i = 0; i < joi.details.length; i += 1) {
+        const path = joi.details[i].path.join('.');
+        result.validation.keys.push(EscapeHtml(path));
+      }
+    }
+    return res.status(statusCode).send(result);
+  };
 };
 
 exports.CelebrateError = (error, segment, opts = { celebrated: false }) => {

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -1,5 +1,14 @@
+const HTTP = require('http');
 const Joi = require('@hapi/joi');
 const { segments } = require('./constants');
+
+const validStatusCodes = Object.keys(HTTP.STATUS_CODES).reduce((memo, status) => {
+  const statusCode = Number(status);
+  if (statusCode > 399 && statusCode < 599) {
+    memo.push(statusCode);
+  }
+  return memo;
+}, []);
 
 exports.REQUESTSCHEMA = Joi.object({
   [segments.HEADERS]: Joi.any(),
@@ -25,4 +34,8 @@ exports.SEGMENTSCHEMA = Joi.string().valid(
 
 exports.CELEBRATEERROROPTSSCHEMA = Joi.object({
   celebrated: Joi.boolean().default(false),
+});
+
+exports.ERRORSOPTSSCHEMA = Joi.object({
+  statusCode: Joi.number().integer().valid(...validStatusCodes),
 });

--- a/package.json
+++ b/package.json
@@ -53,6 +53,6 @@
     "markdown-toc": "1.2.x"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   }
 }

--- a/test/__snapshots__/celebrate.test.js.snap
+++ b/test/__snapshots__/celebrate.test.js.snap
@@ -1,5 +1,19 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`errors() honors the configuration options 1`] = `
+Object {
+  "error": "Conflict",
+  "message": "\\"role\\" must be larger than or equal to 4",
+  "statusCode": 409,
+  "validation": Object {
+    "keys": Array [
+      "role",
+    ],
+    "source": "query",
+  },
+}
+`;
+
 exports[`errors() includes more information when abourtEarly is false 1`] = `
 Object {
   "error": "Bad Request",


### PR DESCRIPTION
Add a config object argument to `errors()`. Right now, this only
lets users tune the status code response.

Updated engine value and travis test matrix for node 12 and "node" to match what the bundled version of Joi does.