### PR TITLE
Move dependencies from @hapi/joi to joi

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -4,7 +4,7 @@ import {
     ValidationOptions,
     ValidationError,
     ValidationResult,
-} from '@hapi/joi';
+} from 'joi';
 
 
 export declare enum Segments {

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,6 @@
 const Assert = require('assert');
 const HTTP = require('http');
-const Joi = require('@hapi/joi');
+const Joi = require('joi');
 const _ = require('lodash');
 const EscapeHtml = require('escape-html');
 const {

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -1,5 +1,5 @@
 const HTTP = require('http');
-const Joi = require('@hapi/joi');
+const Joi = require('joi');
 const { segments } = require('./constants');
 
 const validStatusCodes = Object.keys(HTTP.STATUS_CODES).reduce((memo, status) => {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "homepage": "https://github.com/arb/celebrate#readme",
   "dependencies": {
-    "@hapi/joi": "17.x.x",
+    "joi": "17.x.x",
     "@types/hapi__joi": "17.x.x",
     "escape-html": "1.0.3",
     "lodash": "4.17.x"

--- a/test/__snapshots__/celebrate.test.js.snap
+++ b/test/__snapshots__/celebrate.test.js.snap
@@ -3,7 +3,7 @@
 exports[`errors() honors the configuration options 1`] = `
 Object {
   "error": "Conflict",
-  "message": "\\"role\\" must be larger than or equal to 4",
+  "message": "\\"role\\" must be greater than or equal to 4",
   "statusCode": 409,
   "validation": Object {
     "keys": Array [
@@ -17,7 +17,7 @@ Object {
 exports[`errors() includes more information when abourtEarly is false 1`] = `
 Object {
   "error": "Bad Request",
-  "message": "\\"role\\" must be larger than or equal to 4. \\"name\\" is required",
+  "message": "\\"role\\" must be greater than or equal to 4. \\"name\\" is required",
   "statusCode": 400,
   "validation": Object {
     "keys": Array [
@@ -44,7 +44,7 @@ Object {
 exports[`errors() responds with a joi error from celebrate middleware 1`] = `
 Object {
   "error": "Bad Request",
-  "message": "\\"role\\" must be larger than or equal to 4",
+  "message": "\\"role\\" must be greater than or equal to 4",
   "statusCode": 400,
   "validation": Object {
     "keys": Array [


### PR DESCRIPTION
According to [this](https://github.com/sideway/joi/issues/2411) issue, Joi is leaving @hapi
I updated the dependencies reflecting the contributor's stated request 
```Replace @hapi/joi with joi in your package.json files and your require statement.```