### PR TITLE
Updated package.json with new joi orgranization

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "homepage": "https://github.com/arb/celebrate#readme",
   "dependencies": {
-    "@hapi/joi": "17.x.x",
+    "joi": "17.x.x",
     "@types/hapi__joi": "17.x.x",
     "escape-html": "1.0.3",
     "lodash": "4.17.x"


### PR DESCRIPTION
`joi` has recently been moved from `@hapi/joi` to `joi`. I've updated the `package.json` file with the new organization name.