### PR TITLE
Update `joi` organization and fixed `@hapi/joi' should be listed in the project's dependencies` failure

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -4,7 +4,7 @@ import {
     ValidationOptions,
     ValidationError,
     ValidationResult,
-} from '@hapi/joi';
+} from 'joi';
 
 
 export declare enum Segments {

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,6 @@
 const Assert = require('assert');
 const HTTP = require('http');
-const Joi = require('@hapi/joi');
+const Joi = require('joi');
 const _ = require('lodash');
 const EscapeHtml = require('escape-html');
 const {

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -1,5 +1,5 @@
 const HTTP = require('http');
-const Joi = require('@hapi/joi');
+const Joi = require('joi');
 const { segments } = require('./constants');
 
 const validStatusCodes = Object.keys(HTTP.STATUS_CODES).reduce((memo, status) => {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "homepage": "https://github.com/arb/celebrate#readme",
   "dependencies": {
-    "@hapi/joi": "17.x.x",
+    "joi": "17.x.x",
     "@types/hapi__joi": "17.x.x",
     "escape-html": "1.0.3",
     "lodash": "4.17.x"


### PR DESCRIPTION
joi is leaving the @hapi organization and moving back to 'joi' (https://github.com/sideway/joi/issues/2411). I have updated the `package.json` file accordingly and have updated the following files to reflect the changes:

- lib/index.d.ts 
- lib/index.js
- lib/schema.js