### PR TITLE
Make isCelebrateError a type guard

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -100,7 +100,7 @@ export declare const Joi: joi;
 /**
  * Examines an error object to determine if it originated from the celebrate middleware.
  */
-export declare function isCelebrateError(err: object): boolean;
+export declare function isCelebrateError(err: any): err is CelebrateError;
 
 /**
  * The standard error used by Celebrate


### PR DESCRIPTION
[Typescript type guards](https://www.typescriptlang.org/docs/handbook/advanced-types.html#user-defined-type-guards) return a boolean so this is not a breaking change, and the error returned from the express error middleware is typeof `any` not `object`.