### PR TITLE
added status code override

### DIFF
--- a/lib/CelebrateError.js
+++ b/lib/CelebrateError.js
@@ -18,6 +18,7 @@ exports.CelebrateError = class extends Error {
     super(message);
     this.details = new internals.Details();
     this[internals.CELEBRATED] = Boolean(opts.celebrated);
+    this.statusCode = opts.statusCode;
   }
 };
 

--- a/lib/celebrate.js
+++ b/lib/celebrate.js
@@ -187,6 +187,10 @@ exports.errors = (opts = {}) => {
       return next(err);
     }
 
+    if (err.statusCode) {
+      finalOpts.statusCode = err.statusCode;
+    }
+
     const {
       statusCode,
     } = finalOpts;

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -38,6 +38,7 @@ exports.SEGMENTSCHEMA = Joi.string().valid(
 
 exports.CELEBRATEERROROPTSSCHEMA = Joi.object({
   celebrated: Joi.boolean().default(false),
+  statusCode?: Joi.number().integer().valid(...validStatusCodes),
 });
 
 exports.ERRORSOPTSSCHEMA = Joi.object({


### PR DESCRIPTION
The current behaviour is to always return the same HTTP status code.
This commit allows users to override the returned status code from
individual CelebrateErrors.