### PR TITLE
Fixed celebrator

### DIFF
--- a/lib/celebrate.js
+++ b/lib/celebrate.js
@@ -214,4 +214,4 @@ exports.errors = (opts = {}) => {
 
 exports.Joi = Joi;
 exports.Segments = segments;
-exports.celebrator = _.curryRight(exports.celebrate, 3);
+exports.celebrator = _.curry(_.flip(exports.celebrate), 3);

--- a/test/celebrate.test.js
+++ b/test/celebrate.test.js
@@ -11,6 +11,7 @@ const {
   CelebrateError,
   Segments,
   celebrator,
+  Modes,
 } = require('../lib');
 
 describe('celebrate()', () => {
@@ -557,5 +558,42 @@ describe('CelebrateError()', () => {
     expect(() => {
       err.details.set(Segments.BODY, new Error());
     }).toThrow('value must be a joi validation error');
+  });
+});
+
+describe('celebrator', () => {
+  let c;
+
+  const opts = { reqContext: true, mode: Modes.FULL };
+  const joiOpts = { convert: true };
+  const schema = {
+    [Segments.HEADERS]: Joi.object({
+      name: Joi.string().required(),
+    }),
+  };
+
+  it('can be invoked (opts)(joiOpts)(schema)', () => {
+    expect(() => {
+      c = celebrator(opts)(joiOpts)(schema);
+    }).not.toThrow();
+    expect(c._schema).toEqual(schema);
+  });
+  it('can be invoked (opts, joiOpts)(schema)', () => {
+    expect(() => {
+      c = celebrator(opts, joiOpts)(schema);
+    }).not.toThrow();
+    expect(c._schema).toEqual(schema);
+  });
+  it('can be invoked (opts)(joiOpts, schema)', () => {
+    expect(() => {
+      c = celebrator(opts)(joiOpts, schema);
+    }).not.toThrow();
+    expect(c._schema).toEqual(schema);
+  });
+  it('can be invoked (opts, joiOpts, schema);', () => {
+    expect(() => {
+      c = celebrator(opts, joiOpts, schema);
+    }).not.toThrow();
+    expect(c._schema).toEqual(schema);
   });
 });


### PR DESCRIPTION
Closes #215

The way _.curryRight doesn't really work like you'd think it would, so I
rewrote it to use _.curry and _.flip so that it now works like the documentation
says it does.