### PR TITLE
Closes #219

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2018-2020 Adam Bretz
+Copyright (c) 2018-2021 Adam Bretz
 Copyright (c) 2017 Continuation Labs
 
 Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/README.md
+++ b/README.md
@@ -274,3 +274,4 @@ According the the HTTP spec, `GET` requests should _not_ include a body in the r
 ## Issues
 
 *Before* opening issues on this repo, make sure your joi schema is correct and working as you intended. The bulk of this code is just exposing the joi API as express middleware. All of the heavy lifting still happens inside joi. You can go [here](https://npm.runkit.com/joi) to verify your joi schema easily.
+

--- a/README.md
+++ b/README.md
@@ -274,4 +274,3 @@ According the the HTTP spec, `GET` requests should _not_ include a body in the r
 ## Issues
 
 *Before* opening issues on this repo, make sure your joi schema is correct and working as you intended. The bulk of this code is just exposing the joi API as express middleware. All of the heavy lifting still happens inside joi. You can go [here](https://npm.runkit.com/joi) to verify your joi schema easily.
-

--- a/README.md
+++ b/README.md
@@ -187,6 +187,7 @@ Returns a `function` with the error handler signature (`(err, req, res, next)`).
 
 - `[opts]` - an optional `object` with the following keys
   - `statusCode` - `number` that will be used for the response status code in the event of an error. Must be greater than 399 and less than 600. It must also be a number available to the node [HTTP module](https://nodejs.org/api/http.html#http_http_status_codes). Defaults to 400.
+  - `message` - `string` that will be used for the `message` value sent out by the error handler. Defaults to `'Validation failed'`
 
 If the error response format does not suite your needs, you are encouraged to write your own and check [`isCelebrateError(err)`](#iscelebrateerrorerr) to format celebrate errors to your liking. 
 
@@ -221,9 +222,9 @@ An enum containing all the available validation modes that celebrate can support
 
 ### `new CelebrateError([message], [opts])`
 
-Creates a new `CelebrateError` object.
+Creates a new `CelebrateError` object. Extends the built in `Error` object.
 
-- `message` - optional `string` message. Defaults to `'celebrate request validation failed'`
+- `message` - optional `string` message. Defaults to `'Validation failed'`.
 - `[opts]` - optional `object` with the following keys
   - `celebrated` - `bool` that, when `true`, adds `Symbol('celebrated'): true` to the result object. This indicates this error as originating from `celebrate`. You'd likely want to set this to `true` if you want the celebrate error handler to handle errors originating from the `format` function that you call in user-land code. Defaults to `false`.
 

--- a/lib/CelebrateError.js
+++ b/lib/CelebrateError.js
@@ -14,7 +14,7 @@ internals.Details = class extends Map {
 };
 
 exports.CelebrateError = class extends Error {
-  constructor(message = 'celebrate request validation failed', opts = {}) {
+  constructor(message = 'Validation failed', opts = {}) {
     super(message);
     this.details = new internals.Details();
     this[internals.CELEBRATED] = Boolean(opts.celebrated);

--- a/lib/celebrate.js
+++ b/lib/celebrate.js
@@ -189,6 +189,7 @@ exports.errors = (opts = {}) => {
 
     const {
       statusCode,
+      message,
     } = finalOpts;
 
     const validation = {};
@@ -204,7 +205,7 @@ exports.errors = (opts = {}) => {
     const result = {
       statusCode,
       error: HTTP.STATUS_CODES[statusCode],
-      message: err.message,
+      message: message || err.message,
       validation,
     };
 

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -42,4 +42,5 @@ exports.CELEBRATEERROROPTSSCHEMA = Joi.object({
 
 exports.ERRORSOPTSSCHEMA = Joi.object({
   statusCode: Joi.number().integer().valid(...validStatusCodes),
+  message: Joi.string(),
 });

--- a/test/__snapshots__/celebrate.test.js.snap
+++ b/test/__snapshots__/celebrate.test.js.snap
@@ -11,7 +11,7 @@ Map {
 exports[`errors() honors the configuration options 1`] = `
 Object {
   "error": "Conflict",
-  "message": "celebrate request validation failed",
+  "message": "your request is bad and you should feel bad",
   "statusCode": 409,
   "validation": Object {
     "query": Object {
@@ -28,7 +28,7 @@ Object {
 exports[`errors() includes more information when abourtEarly is false 1`] = `
 Object {
   "error": "Bad Request",
-  "message": "celebrate request validation failed",
+  "message": "Validation failed",
   "statusCode": 400,
   "validation": Object {
     "query": Object {
@@ -46,7 +46,7 @@ Object {
 exports[`errors() responds with a joi error from celebrate middleware 1`] = `
 Object {
   "error": "Bad Request",
-  "message": "celebrate request validation failed",
+  "message": "Validation failed",
   "statusCode": 400,
   "validation": Object {
     "query": Object {

--- a/test/celebrate.test.js
+++ b/test/celebrate.test.js
@@ -446,21 +446,23 @@ describe('errors()', () => {
   });
 
   it('honors the configuration options', () => {
-    expect.assertions(4);
+    expect.assertions(5);
     const middleware = celebrate({
       [Segments.QUERY]: {
         role: Joi.number().integer().min(4),
       },
     });
     const statusCode = 409;
-    const handler = errors({ statusCode });
+    const message = 'your request is bad and you should feel bad';
+    const handler = errors({ statusCode, message });
     const next = jest.fn();
     const res = {
       status(code) {
         expect(code).toBe(statusCode);
         return {
           send(err) {
-            expect(err).toHaveProperty('statusCode', 409);
+            expect(err).toHaveProperty('statusCode', statusCode);
+            expect(err).toHaveProperty('message', message);
             expect(err).toMatchSnapshot();
             expect(next).not.toHaveBeenCalled();
           },
@@ -527,7 +529,7 @@ describe('CelebrateError()', () => {
     const err = new CelebrateError(undefined, { celebrated: true });
     err.details.set(Segments.BODY, result.error);
 
-    expect(err).toHaveProperty('message', 'celebrate request validation failed');
+    expect(err).toHaveProperty('message', 'Validation failed');
     expect(err.details.get(Segments.BODY)).toBe(result.error);
     expect(isCelebrateError(err)).toBe(true);
   });
@@ -547,7 +549,7 @@ describe('CelebrateError()', () => {
       const err = new CelebrateError();
       err.details.set(Segments.QUERY, e);
 
-      expect(err).toHaveProperty('message', 'celebrate request validation failed');
+      expect(err).toHaveProperty('message', 'Validation failed');
       expect(err.details.get(Segments.QUERY)).toBe(e);
       expect(isCelebrateError(err)).toBe(false);
     });


### PR DESCRIPTION
Adds additional `message` value to the options argument to `errors()`. Also,
changed the default `message` value of CelebrateError to 'Validation failed'.