### PR TITLE
Refactor: Remove lodash dependency and implement custom functional utilities

### DIFF
--- a/lib/CelebrateError.js
+++ b/lib/CelebrateError.js
@@ -1,6 +1,5 @@
 /* eslint-disable max-classes-per-file */
 const Assert = require('assert');
-const _ = require('lodash');
 
 const internals = {
   CELEBRATED: Symbol('celebrated'),
@@ -8,7 +7,7 @@ const internals = {
 
 internals.Details = class extends Map {
   set(key, value) {
-    Assert.ok(_.get(value, 'isJoi', false), 'value must be a joi validation error');
+    Assert.ok(value && value.isJoi, 'value must be a joi validation error');
     super.set(key, value);
   }
 };
@@ -21,4 +20,4 @@ exports.CelebrateError = class extends Error {
   }
 };
 
-exports.isCelebrateError = (err) => _.get(err, internals.CELEBRATED, false);
+exports.isCelebrateError = (err) => Boolean(err && err[internals.CELEBRATED]);

--- a/lib/celebrate.js
+++ b/lib/celebrate.js
@@ -1,7 +1,7 @@
 const HTTP = require('http');
 const Joi = require('joi');
-const _ = require('lodash');
 const EscapeHtml = require('escape-html');
+const { curry, flip } = require('./functional');
 const {
   CELEBRATEOPTSSCHEMA,
   REQUESTSCHEMA,
@@ -214,4 +214,4 @@ exports.errors = (opts = {}) => {
 
 exports.Joi = Joi;
 exports.Segments = segments;
-exports.celebrator = _.curry(_.flip(exports.celebrate), 3);
+exports.celebrator = curry(flip(exports.celebrate), 3);

--- a/lib/functional.js
+++ b/lib/functional.js
@@ -1,0 +1,27 @@
+/**
+ * Reverse argument order (lodash-compatible flip for variadic calls).
+ */
+function flip(fn) {
+  return function flipped(...args) {
+    return fn.apply(this, [...args].reverse());
+  };
+}
+
+/**
+ * Curry a function to arity `n` (lodash-compatible partial application).
+ */
+function curry(fn, arity) {
+  return function curried(...args) {
+    if (args.length >= arity) {
+      return fn.apply(this, args.slice(0, arity));
+    }
+    return function curriedPartial(...more) {
+      return curried.apply(this, args.concat(more));
+    };
+  };
+}
+
+module.exports = {
+  curry,
+  flip,
+};

--- a/package.json
+++ b/package.json
@@ -30,8 +30,7 @@
   "homepage": "https://github.com/arb/celebrate#readme",
   "dependencies": {
     "escape-html": "1.0.3",
-    "joi": "17.x.x",
-    "lodash": "4.17.x"
+    "joi": "17.x.x"
   },
   "devDependencies": {
     "@hapi/teamwork": "5.1.0",


### PR DESCRIPTION
- Removed lodash usage from celebrate.js and CelebrateError.js, replacing it with custom `curry` and `flip` functions defined in a new functional.js file.
- Updated package.json to reflect the removal of lodash from dependencies.

Arbitrary Code Injection
Affecting [lodash](https://security.snyk.io/package/npm/lodash) package, versions <4.18.1
https://security.snyk.io/vuln/SNYK-JS-LODASH-15869625