### PR TITLE
ci: refresh matrix with current express dist-tags and node LTS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,8 +17,8 @@ jobs:
     strategy:
       matrix:
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
-        node-version: [12.x, 14.x, 16.x, 18.x, latest]
-        express-version: [latest, next]
+        node-version: [20.x, 22.x, 24.x, 25.x]
+        express-version: [latest-4, latest]
     steps:
     - uses: actions/checkout@v3
     - name: Use Node.js ${{ matrix.node-version }}


### PR DESCRIPTION
## What

The CI matrix has been failing because `npm install express@next` errors out with `ETARGET No matching version found for express@next`. This PR replaces the no-longer-published `next` dist-tag with the tags express actually ships today, and refreshes the Node.js side of the matrix to current supported lines.

## Why

When this workflow was originally set up, express used the long-running convention of `latest` for the current 4.x release and `next` for the in-progress v5 prereleases (the alpha/beta line). That convention ended when [express 5 shipped in October 2024](https://expressjs.com/2024/10/15/v5-release.html): `5.x` was eventually promoted to `latest`, a new `latest-4` tag was introduced for people who want to keep installing v4, and `next` was dropped entirely (there is no in-flight v6 prerelease line for it to point at).

```
$ npm view express dist-tags
{ "latest": "5.2.1", "latest-4": "4.22.1" }
```

So `express@next` no longer resolves to anything, and every matrix job fails at the `npm install` step.

While in here, the Node.js side of the matrix was also stale. `12.x`, `14.x`, `16.x`, and `18.x` are all EOL per [nodejs.org/en/about/previous-releases](https://nodejs.org/en/about/previous-releases). The currently supported lines are 20 (LTS Iron), 22 (LTS Jod), 24 (LTS Krypton), and 25 (Current). All four are compatible with both Express 4 and Express 5 (Express 5 requires Node >= 18).

## What's different now

`.github/workflows/ci.yml` matrix:

```diff
-        node-version: [12.x, 14.x, 16.x, 18.x, latest]
-        express-version: [latest, next]
+        node-version: [20.x, 22.x, 24.x, 25.x]
+        express-version: [latest-4, latest]
```

That gives an 8-job matrix covering every active Node line (20, 22, 24 LTS plus 25 Current) against both Express major lines (4 via `latest-4`, 5 via `latest`).

## Future cleanup (out of scope)

Two harmless warnings remain in the workflow output and could be addressed separately:
- `actions/setup-node@v3` logs `Unexpected input(s) 'express-version'` because that input is being passed to the wrong step. The value is consumed two steps later by the `json -I -f package.json ...` rewrite, so the warning is cosmetic.
- `actions/checkout@v3` and `actions/setup-node@v3` are on Node 20 and will be force-bumped to Node 24 by GitHub starting June 2, 2026. Bumping both to `@v4` would silence the deprecation notice.



Made with [Cursor](https://cursor.com)