### PR TITLE
ci: bump checkout/setup-node to v4 and drop unused setup-node input

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,12 +20,11 @@ jobs:
         node-version: [20.x, 22.x, 24.x, 25.x]
         express-version: [latest-4, latest]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.node-version }}
-        express-version: ${{ matrix.express-version }}
     - run: npm install -g codecov
     - run: npm install -g json
     - run: json -I -f package.json -e "this.devDependencies.express=\"${{ matrix.express-version }}\"" 


### PR DESCRIPTION
## What

Cleans up the two warning annotations that show on every matrix job after the previous CI fix landed in #252. No functional change, no behavior change — just silences the warnings.

```diff
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Use Node.js \${{ matrix.node-version }}
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version: \${{ matrix.node-version }}
-        express-version: \${{ matrix.express-version }}
```

## Why

Two distinct warnings, both from the runner:

**1. Node.js 20 actions are deprecated.**

`actions/checkout@v3` and `actions/setup-node@v3` are bundled to run on Node.js 20. Per the [GitHub Actions deprecation notice](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/):
- Starting **June 2, 2026**, Node 20 actions will be force-bumped to Node 24 by default.
- Starting **September 16, 2026**, Node 20 will be removed from the runner entirely.

Bumping both to `@v4` (which ships on Node 24) gets us off the deprecation warning and ahead of both deadlines.

**2. Unexpected input(s) 'express-version'.**

`actions/setup-node` only accepts a fixed set of inputs (`always-auth`, `node-version`, `node-version-file`, `architecture`, `check-latest`, `registry-url`, `scope`, `token`, `cache`, `cache-dependency-path`). `express-version` was being passed in but silently ignored — `setup-node` has no concept of npm packages and cannot influence which Express version is installed.

The matrix value has always been picked up two steps later by the `json -I -f package.json -e "this.devDependencies.express=\"\${{ matrix.express-version }}\""` rewrite, which is the actual mechanism that swaps the Express version before `npm install` runs. That step is unchanged, so all 8 matrix combinations continue to test the same Express versions they did before.