### PR TITLE
fix(deps): bump body-parser devDep to 1.20.x to clear CVE

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@types/express": "4.x.x",
     "artificial": "1.x.x",
     "benchmark": "2.1.x",
-    "body-parser": "1.19.x",
+    "body-parser": "1.20.x",
     "cookie-parser": "1.4.x",
     "cookie-signature": "1.1.x",
     "eslint": "8.x.x",


### PR DESCRIPTION
## Summary

Closes [Dependabot alert #1](https://github.com/arb/celebrate/security/dependabot/1) (high severity DoS in `body-parser` < 1.20.3 when URL encoding is enabled) by bumping the `devDependencies` pin from `1.19.x` to `1.20.x`.

`body-parser` is a development-only dependency in this repo (used in `test/integration.test.js` to wire `BodyParser.json()` into the test Express server). Consumers of the published `celebrate` package never install it transitively, so this change has zero impact on downstream users.

## Why this is non-breaking

- `1.19.x` -> `1.20.x` is a same-major bump per semver; the `BodyParser.json()` API used by the test suite is unchanged.
- Latest 1.x is `1.20.5`, well above the `1.20.3` first-patched version.
- The change is independent of the `express-version` matrix in `.github/workflows/ci.yml` (`latest-4`, `latest`).

## Verification

Locally, mirroring the CI `latest` matrix cell (rewriting `express` to `latest` since the repo pins `express: next` and there is no `next` dist-tag at the moment):

- `npm install` resolves `body-parser@1.20.5`
- `npm run test:ci` -> 68/68 tests pass, lint clean, 100% coverage

Made with [Cursor](https://cursor.com)