### PR TITLE
docs: point build badge at celebrate repo instead of placeholder

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![celebrate](https://github.com/arb/celebrate/raw/master/images/logo.svg?sanitize=1)](https://www.npmjs.org/package/celebrate)
 
 [![Current Version](https://flat.badgen.net/npm/v/celebrate?icon=npm)](https://www.npmjs.org/package/celebrate)
-[![Build Status](https://flat.badgen.net/github/checks/arb/celebrate?label=build&icon=github)](https://www.google.com)
+[![Build Status](https://flat.badgen.net/github/checks/arb/celebrate?label=build&icon=github)](https://github.com/arb/celebrate)
 [![airbnb-style](https://flat.badgen.net/badge/eslint/airbnb/ff5a5f?icon=airbnb)](https://github.com/airbnb/javascript)
 [![Code Coverage](https://flat.badgen.net/codecov/c/github/arb/celebrate?icon=codecov)](https://codecov.io/gh/arb/celebrate)
 [![Total Downloads](https://flat.badgen.net/npm/dt/celebrate?&color=cyan)](https://www.npmjs.org/package/celebrate)


### PR DESCRIPTION
## Summary

The Build Status badge on line 4 of [README.md](README.md) was linking to `https://www.google.com` (a leftover placeholder). Point it at the celebrate GitHub repo so it matches the convention of the surrounding badges, each of which links to its source.

The badgen URL itself is unchanged. With the dependabot alert resolved in #254, `https://flat.badgen.net/github/checks/arb/celebrate` returns `success` again, so no further changes to the badge endpoint are needed.

## Trade-off

The unpinned `/github/checks/:owner/:repo` form aggregates every check on the latest commit of the default branch. If a future non-CI check (another Dependabot security update, CodeQL, etc.) ever fails on master, this badge will go red even when `Node.js CI` is green. We've opted to accept that in exchange for keeping the badge URL visually consistent with the other badges in the README.