### PR TITLE
feat!: migrate to native ESM, drop CommonJS support

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,13 +45,17 @@ celebrate lists joi as a formal dependency. This means that celebrate will alway
 
 celebrate is tested and has full compatibility with express 4 and 5. It likely works correctly with express 3, but including it in the test matrix was more trouble than it's worth. This is primarily because express 3 exposes route parameters as an array rather than an object.
 
+## 16.x breaking changes
+
+celebrate 16 ships as a native ES module. `require('celebrate')` is no longer supported — use `import` syntax instead. The minimum supported Node version is unchanged at 20+.
+
 ## Example Usage
 
 Example of using celebrate on a single POST route to validate `req.body`.
 ```js
-const express = require('express');
-const BodyParser = require('body-parser');
-const { celebrate, Joi, errors, Segments } = require('celebrate');
+import express from 'express';
+import BodyParser from 'body-parser';
+import { celebrate, Joi, errors, Segments } from 'celebrate';
 
 const app = express();
 app.use(BodyParser.json());
@@ -74,8 +78,8 @@ app.use(errors());
 
 Example of using celebrate to validate all incoming requests to ensure the `token` header is present and matches the supplied regular expression.
 ```js
-const express = require('express');
-const { celebrate, Joi, errors, Segments } = require('celebrate');
+import express from 'express';
+import { celebrate, Joi, errors, Segments } from 'celebrate';
 const app = express();
 
 // validate all incoming request headers for the token header
@@ -120,8 +124,8 @@ This is a curried version of [`celebrate`](#celebrateschema-joioptions-opts). It
   This is an example use of curried celebrate in a real server.
 
   ```js
-    const express = require('express');
-    const { celebrator, Joi, errors, Segments } = require('celebrate');
+    import express from 'express';
+    import { celebrator, Joi, errors, Segments } from 'celebrate';
     const app = express();
 
     // now every instance of `celebrate` will use these same options so you only

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,8 +1,8 @@
-const neostandard = require('neostandard');
-const globals = require('globals');
+import neostandard from 'neostandard';
+import globals from 'globals';
 
-module.exports = [
-  ...neostandard({ noJsx: true, node: true, commonjs: true, semi: true }),
+export default [
+  ...neostandard({ noJsx: true, node: true, semi: true }),
   {
     languageOptions: {
       globals: {

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,7 +1,10 @@
-module.exports = {
+export default {
   testEnvironment: 'node',
   collectCoverage: true,
-  collectCoverageFrom: ['<rootDir>/lib/index.js'],
+  collectCoverageFrom: [
+    '<rootDir>/lib/**/*.js',
+    '!<rootDir>/lib/index.js',
+  ],
   coverageDirectory: '<rootDir>/coverage',
   coverageThreshold: {
     global: {

--- a/lib/CelebrateError.js
+++ b/lib/CelebrateError.js
@@ -1,4 +1,4 @@
-const Assert = require('node:assert');
+import Assert from 'node:assert';
 
 const internals = {
   CELEBRATED: Symbol('celebrated'),
@@ -11,12 +11,12 @@ internals.Details = class extends Map {
   }
 };
 
-exports.CelebrateError = class extends Error {
+export class CelebrateError extends Error {
   constructor (message = 'Validation failed', opts = {}) {
     super(message);
     this.details = new internals.Details();
     this[internals.CELEBRATED] = Boolean(opts.celebrated);
   }
-};
+}
 
-exports.isCelebrateError = (err) => err?.[internals.CELEBRATED] === true;
+export const isCelebrateError = (err) => err?.[internals.CELEBRATED] === true;

--- a/lib/celebrate.js
+++ b/lib/celebrate.js
@@ -1,18 +1,18 @@
-const { STATUS_CODES } = require('node:http');
-const Joi = require('joi');
-const EscapeHtml = require('escape-html');
-const curry = require('lodash.curry');
-const flip = require('lodash.flip');
-const {
+import { STATUS_CODES } from 'node:http';
+import Joi from 'joi';
+import EscapeHtml from 'escape-html';
+import curry from 'lodash.curry';
+import flip from 'lodash.flip';
+import {
   CELEBRATEOPTSSCHEMA,
   REQUESTSCHEMA,
   ERRORSOPTSSCHEMA,
-} = require('./schema');
-const { segments, modes } = require('./constants');
-const {
+} from './schema.js';
+import { segments, modes } from './constants.js';
+import {
   CelebrateError,
   isCelebrateError,
-} = require('./CelebrateError');
+} from './CelebrateError.js';
 
 const internals = {
   DEFAULT_ERROR_ARGS: {
@@ -107,7 +107,7 @@ internals.validateFns = {
   [modes.PARTIAL]: internals.partialValidate,
 };
 
-exports.celebrate = (_requestRules, joiOpts = {}, opts = {}) => {
+export const celebrate = (_requestRules, joiOpts = {}, opts = {}) => {
   Joi.assert(_requestRules, REQUESTSCHEMA);
   Joi.assert(opts, CELEBRATEOPTSSCHEMA);
 
@@ -146,7 +146,7 @@ exports.celebrate = (_requestRules, joiOpts = {}, opts = {}) => {
   return middleware;
 };
 
-exports.errors = (opts = {}) => {
+export const errors = (opts = {}) => {
   const finalOpts = { ...internals.DEFAULT_ERRORS_OPTS, ...opts };
   Joi.assert(finalOpts, ERRORSOPTSSCHEMA);
 
@@ -177,6 +177,6 @@ exports.errors = (opts = {}) => {
   };
 };
 
-exports.Joi = Joi;
-exports.Segments = segments;
-exports.celebrator = curry(flip(exports.celebrate), 3);
+export { Joi };
+export const Segments = segments;
+export const celebrator = curry(flip(celebrate), 3);

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -1,4 +1,4 @@
-exports.segments = {
+export const segments = {
   BODY: 'body',
   COOKIES: 'cookies',
   HEADERS: 'headers',
@@ -7,7 +7,7 @@ exports.segments = {
   SIGNEDCOOKIES: 'signedCookies',
 };
 
-exports.modes = {
+export const modes = {
   FULL: 'full',
   PARTIAL: 'partial',
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,27 +1,3 @@
-const {
-  celebrate,
-  celebrator,
-  errors,
-  Joi,
-} = require('./celebrate');
-
-const {
-  segments: Segments,
-  modes: Modes,
-} = require('./constants');
-
-const {
-  CelebrateError,
-  isCelebrateError,
-} = require('./CelebrateError');
-
-module.exports = {
-  celebrate,
-  celebrator,
-  errors,
-  CelebrateError,
-  isCelebrateError,
-  Joi,
-  Segments,
-  Modes,
-};
+export { celebrate, celebrator, errors, Joi, Segments } from './celebrate.js';
+export { modes as Modes } from './constants.js';
+export { CelebrateError, isCelebrateError } from './CelebrateError.js';

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -1,9 +1,6 @@
-const { STATUS_CODES } = require('node:http');
-const Joi = require('joi');
-const {
-  segments,
-  modes,
-} = require('./constants');
+import { STATUS_CODES } from 'node:http';
+import Joi from 'joi';
+import { segments, modes } from './constants.js';
 
 const validStatusCodes = [];
 for (const status of Object.keys(STATUS_CODES)) {
@@ -13,7 +10,7 @@ for (const status of Object.keys(STATUS_CODES)) {
   }
 }
 
-exports.REQUESTSCHEMA = Joi.object({
+export const REQUESTSCHEMA = Joi.object({
   [segments.HEADERS]: Joi.any(),
   [segments.PARAMS]: Joi.any(),
   [segments.QUERY]: Joi.any(),
@@ -22,12 +19,12 @@ exports.REQUESTSCHEMA = Joi.object({
   [segments.BODY]: Joi.any(),
 }).required().min(1);
 
-exports.CELEBRATEOPTSSCHEMA = Joi.object({
+export const CELEBRATEOPTSSCHEMA = Joi.object({
   reqContext: Joi.boolean(),
   mode: Joi.string().valid(modes.PARTIAL, modes.FULL),
 });
 
-exports.SEGMENTSCHEMA = Joi.string().valid(
+export const SEGMENTSCHEMA = Joi.string().valid(
   segments.HEADERS,
   segments.PARAMS,
   segments.QUERY,
@@ -36,11 +33,11 @@ exports.SEGMENTSCHEMA = Joi.string().valid(
   segments.BODY
 );
 
-exports.CELEBRATEERROROPTSSCHEMA = Joi.object({
+export const CELEBRATEERROROPTSSCHEMA = Joi.object({
   celebrated: Joi.boolean().default(false),
 });
 
-exports.ERRORSOPTSSCHEMA = Joi.object({
+export const ERRORSOPTSSCHEMA = Joi.object({
   statusCode: Joi.number().integer().valid(...validStatusCodes),
   message: Joi.string(),
 });

--- a/package.json
+++ b/package.json
@@ -4,14 +4,20 @@
   "description": "A joi validation middleware for Express.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
-  "type": "commonjs",
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./lib/index.d.ts",
+      "default": "./lib/index.js"
+    }
+  },
   "engines": {
     "node": ">=20"
   },
   "scripts": {
     "test": "is-ci 'test:ci' 'test:local'",
-    "test:local": "jest --watch --verbose",
-    "test:ci": "jest --ci",
+    "test:local": "node --experimental-vm-modules node_modules/.bin/jest --watch --verbose",
+    "test:ci": "node --experimental-vm-modules node_modules/.bin/jest --ci",
     "benchmark": "node utils/benchmark",
     "toc": "node utils/generate-toc",
     "version": "npm run toc && git add README.md"

--- a/test/celebrate.test.js
+++ b/test/celebrate.test.js
@@ -1,5 +1,6 @@
-const { faker } = require('@faker-js/faker');
-const {
+import { jest } from '@jest/globals';
+import { faker } from '@faker-js/faker';
+import {
   celebrate,
   Joi,
   errors,
@@ -8,7 +9,7 @@ const {
   Segments,
   celebrator,
   Modes,
-} = require('../lib');
+} from '../lib/index.js';
 
 describe('celebrate()', () => {
   describe.each`
@@ -120,6 +121,53 @@ describe('celebrate()', () => {
     }, null, (err) => {
       expect(isCelebrateError(err)).toBe(true);
       expect(err.details).toMatchSnapshot();
+    });
+  });
+
+  it('applies joi transforms back to the request object in full validate mode', () => {
+    expect.assertions(3);
+    const first = faker.person.firstName();
+    const role = faker.person.jobTitle();
+    const req = {
+      [Segments.BODY]: { first },
+      [Segments.QUERY]: { id: '42' },
+      method: 'POST',
+    };
+    const middleware = celebrate({
+      [Segments.BODY]: {
+        first: Joi.string().required(),
+        role: Joi.string().default(role),
+      },
+      [Segments.QUERY]: Joi.object().keys({
+        id: Joi.number().integer(),
+      }),
+    }, { convert: true }, { mode: Modes.FULL });
+
+    return middleware(req, null, (err) => {
+      expect(err).toBe(null);
+      expect(req.body).toEqual({ first, role });
+      expect(req.query).toEqual({ id: 42 });
+    });
+  });
+
+  it('skips body validation in full validate mode for GET requests', () => {
+    expect.assertions(2);
+    const req = {
+      [Segments.QUERY]: { id: '7' },
+      method: 'GET',
+    };
+    const middleware = celebrate({
+      [Segments.BODY]: {
+        first: Joi.string().required(),
+      },
+      [Segments.QUERY]: Joi.object().keys({
+        id: Joi.number().integer(),
+      }),
+    }, { convert: true }, { mode: Modes.FULL });
+
+    return middleware(req, null, (err) => {
+      expect(err).toBe(null);
+      expect(req.query).toEqual({ id: 7 });
     });
   });
 

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -1,15 +1,16 @@
-const Express = require('express');
-const Artificial = require('artificial');
-const signature = require('cookie-signature');
-const CookieParser = require('cookie-parser');
-const { faker } = require('@faker-js/faker');
-const Teamwork = require('@hapi/teamwork');
-const {
+import { jest } from '@jest/globals';
+import Express from 'express';
+import Artificial from 'artificial';
+import signature from 'cookie-signature';
+import CookieParser from 'cookie-parser';
+import { faker } from '@faker-js/faker';
+import Teamwork from '@hapi/teamwork';
+import {
   celebrate,
   Joi,
   Segments,
   isCelebrateError,
-} = require('../lib');
+} from '../lib/index.js';
 
 const cookieSecret = faker.string.alphanumeric();
 

--- a/utils/benchmark.js
+++ b/utils/benchmark.js
@@ -1,5 +1,5 @@
-const { Bench } = require('tinybench');
-const { celebrate, Joi, Modes } = require('../lib');
+import { Bench } from 'tinybench';
+import { celebrate, Joi, Modes } from '../lib/index.js';
 
 const noop = () => {};
 
@@ -41,10 +41,8 @@ bench
     params: {},
   }, {}, noop));
 
-(async () => {
-  await bench.run();
-  console.table(bench.table());
-})();
+await bench.run();
+console.table(bench.table());
 
 // first run
 // valid x 707,830 ops/sec ±7.21% (69 runs sampled)

--- a/utils/generate-toc.js
+++ b/utils/generate-toc.js
@@ -1,5 +1,5 @@
-const Fs = require('node:fs/promises');
-const Toc = require('markdown-toc');
+import Fs from 'node:fs/promises';
+import Toc from 'markdown-toc';
 
 const filename = './README.md';
 
@@ -18,4 +18,4 @@ const generate = async () => {
   await Fs.writeFile(filename, output);
 };
 
-generate();
+await generate();


### PR DESCRIPTION
## What and why

celebrate ships as a native ES module starting with the 16.x line. `require('celebrate')` no longer works; consumers use named import syntax instead:

```js
import { celebrate, Joi, errors, Segments } from 'celebrate';
```

This is a hard break for CJS consumers, but it's the right time: the 16.x line is already shifting supported versions, the published surface stays identical (8 named exports, all preserved), and Node 20+ — celebrate's existing floor — has had stable ESM support for years. Dual-package was considered and rejected to keep the source clean and avoid a build step.

## What's different

- **Public API surface unchanged.** The same 8 named exports (`celebrate`, `celebrator`, `errors`, `Joi`, `Segments`, `Modes`, `CelebrateError`, `isCelebrateError`) are reachable from `'celebrate'`. There is no default export, by design — see follow-up note below.
- **Source converted to ESM.** All of [lib/](lib/), [utils/](utils/), [test/](test/), [jest.config.js](jest.config.js), and [eslint.config.js](eslint.config.js) use `import`/`export` syntax. The `.js` extensions on relative imports are mandatory under ESM.
- **`package.json`** now declares `"type": "module"` and adds an `"exports"` field that maps `"."` to `./lib/index.js`. The `"main"` field is kept as a fallback for older tooling.
- **Jest scripts** invoke `node --experimental-vm-modules node_modules/.bin/jest` because Jest's ESM support still requires the flag. Test files now also `import { jest } from '@jest/globals'` since the global is no longer auto-injected under VM Modules.
- **README** updates the four `require('celebrate')` examples to import syntax and adds a "16.x breaking changes" callout near the top.

## Coverage scope widened

The previous Jest config only collected coverage from [lib/index.js](lib/index.js), the barrel. Under ESM that's a pure re-export file with no executable code, so it always shows 0% — and the narrow scope had been hiding gaps in the real implementation files. The new config widens to `lib/**/*.js` (excluding the barrel) and surfaced two previously untested paths:

- The success path of FULL-mode validation in `internals.fullValidate`
- The `value == null` branch when FULL mode is used with a GET request that has a body schema

Two minimal tests were added to [test/celebrate.test.js](test/celebrate.test.js) to restore the 100% threshold across statements, branches, functions, and lines.

## Design note: no default exports in published code

The published API is intentionally all named exports — no `export default` anywhere reachable from `'celebrate'`. This means `import celebrate from 'celebrate'` will fail with a syntax error, forcing consumers onto explicit named imports. The single `export default` in the repo is in [eslint.config.js](eslint.config.js), which ESLint flat config requires; it's not part of the package payload.

## Follow-up

[#260](https://github.com/arb/celebrate/issues/260) tracks evaluating Vitest as a Jest replacement. The `--experimental-vm-modules` flag and the `@jest/globals` import are friction points specific to Jest's ESM story; the test suite has no `jest.mock` usage so a Vitest port should be near-mechanical.
