### PR TITLE
ci: migrate Codecov upload from deprecated CLI to codecov-action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,8 +25,24 @@ jobs:
       uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.node-version }}
-    - run: npm install -g codecov
     - run: npm pkg set "devDependencies.express=${{ matrix.express-version }}"
     - run: npm install
     - run: npx eslint .
     - run: npm test
+
+  coverage:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-node@v4
+      with:
+        node-version: 22.x
+    - run: npm install
+    - run: npm test
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v5
+      with:
+        files: ./coverage/lcov.info
+        fail_ci_if_error: false
+      env:
+        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
Closes #258.

## What and why

Our CI was globally installing the long-deprecated [`codecov` npm CLI](https://www.npmjs.com/package/codecov) in every cell of the build matrix (4 Node × 2 Express = 8 jobs) but never actually invoking it — so coverage hasn't really been making it to Codecov for a while. This swaps in the official [`codecov/codecov-action`](https://github.com/codecov/codecov-action), which is the maintained, signed path forward.

## What's different

- `npm install -g codecov` is gone from the `build` job.
- New `coverage` job runs in parallel to `build`, on a single Node 22 runner (no matrix), runs `npm test` once, and uploads `coverage/lcov.info` via `codecov/codecov-action@v5`.
- Pinned to v5 (current stable major) rather than v6, which was released ~5 weeks ago and bumps the minimum runner version. Easy to bump later.
- `fail_ci_if_error: false` so a Codecov hiccup doesn't redden the run.

Jest already emits `coverage/lcov.info` (default `lcov` reporter, output dir set in `jest.config.js`), so no test config changes were needed.

## Action required before this actually publishes coverage

1. **Add a `CODECOV_TOKEN` repository secret** (Settings → Secrets and variables → Actions). Public repos can technically upload tokenless, but Codecov now recommends tokened uploads.

2. **Fix the silently-no-op `npm test` in CI** (pre-existing issue, not introduced here). Inspecting the CI log on this PR — and on the latest master run (`ae850d0`) — shows that across all matrix cells `npm test` prints `> is-ci 'test:ci' 'test:local'` and exits 0 in ~0.1s without ever invoking Jest. As a result the new `coverage` job currently logs `not_found_files: ["coverage/lcov.info"]` from Codecov. The action itself is wired correctly; it just has nothing to upload until that bug is fixed. Worth filing as its own issue and probably blocks any meaningful coverage trend until resolved.

## QA Spec

- [x] `build` matrix (8 cells) all pass without the global `codecov` install
- [x] `coverage` job runs and the codecov-action step executes against the correct path
- [ ] After (1) above is done and tests actually run, a new commit shows up at https://app.codecov.io/gh/arb/celebrate

## Future cleanup

- Pre-existing: `npm test` no-ops in CI (see "Action required" #2). Out of scope here; keeping this PR focused on the upload-mechanism swap requested by #258.