### PR TITLE
fix(ci): use is-ci-cli binary so npm test actually runs Jest

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "node": ">=20"
   },
   "scripts": {
-    "test": "is-ci 'test:ci' 'test:local'",
+    "test": "is-ci-cli test:ci test:local",
     "test:local": "node --experimental-vm-modules node_modules/.bin/jest --watch --verbose",
     "test:ci": "node --experimental-vm-modules node_modules/.bin/jest --ci",
     "benchmark": "node utils/benchmark",


### PR DESCRIPTION
## What and why

Surprising bug: `npm test` has been silently green-without-tests in CI for some time. Across every matrix cell on master (`ae850d0`), the test step prints `> is-ci 'test:ci' 'test:local'` and exits in ~0.1s without ever invoking Jest. No `Tests: N passed` line, no coverage written.

## Root cause

Two installed packages publish a binary called `is-ci`:

1. The standalone [`is-ci`](https://www.npmjs.com/package/is-ci) package, pulled in transitively. Its bin is literally:

   ```js
   process.exit(require('./') ? 0 : 1)
   ```

   It exits 0 in CI, 1 otherwise. Arguments are ignored.

2. Our [`is-ci-cli`](https://www.npmjs.com/package/is-ci-cli) devDep, which exposes **both** `is-ci` and `is-ci-cli` binaries pointing at the same `cli.js` (the one that actually spawns the named npm script).

When both are installed, `node_modules/.bin/is-ci` wins for whichever package was linked last. In this repo it's the standalone package:

```
node_modules/.bin/is-ci -> ../is-ci/bin.js
```

So `"test": "is-ci 'test:ci' 'test:local'"` invoked the dummy bin and silently succeeded. The `is-ci-cli` README documents the correct invocation as the unambiguous binary `is-ci-cli` -- using that name avoids the collision entirely.

## The fix

One word in `package.json`:

```diff
-    "test": "is-ci 'test:ci' 'test:local'",
+    "test": "is-ci-cli test:ci test:local",
```

(Quotes also dropped to match the package's documented usage; no spaces in the script names.)

## Local verification

```
$ rm -rf coverage && CI=true npm test
> is-ci-cli test:ci test:local
> node --experimental-vm-modules node_modules/.bin/jest --ci
...
All files          |     100 |      100 |     100 |     100 |
Test Suites: 2 passed, 2 total
Tests:       62 passed, 62 total
$ ls -la coverage/lcov.info
-rw-r--r-- 1 ... 2259 ... coverage/lcov.info
```

## Related

Unblocks #262 (codecov-action migration) -- once both merge, the new `coverage` job will actually have an `lcov.info` file to upload.