### PR TITLE
docs: migrate README badges from badgen to shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 [![celebrate](https://github.com/arb/celebrate/raw/master/images/logo.svg?sanitize=1)](https://www.npmjs.org/package/celebrate)
 
-[![Current Version](https://flat.badgen.net/npm/v/celebrate)](https://www.npmjs.org/package/celebrate)
-[![Build Status](https://flat.badgen.net/github/checks/arb/celebrate?label=build&icon=github)](https://github.com/arb/celebrate)
-[![Neo Standard](https://badgen.net/badge/style/neostandard?color=ff80ff)](https://github.com/neostandard/neostandard#readme-badges)
-[![Code Coverage](https://flat.badgen.net/codecov/c/github/arb/celebrate?icon=codecov)](https://codecov.io/gh/arb/celebrate)
-[![Total Downloads](https://flat.badgen.net/npm/dt/celebrate?&color=cyan)](https://www.npmjs.org/package/celebrate)
+[![Current Version](https://img.shields.io/npm/v/celebrate?style=flat)](https://www.npmjs.org/package/celebrate)
+[![Build Status](https://img.shields.io/github/actions/workflow/status/arb/celebrate/ci.yml?branch=master&style=flat&label=build&logo=github)](https://github.com/arb/celebrate/actions/workflows/ci.yml)
+[![Neo Standard](https://img.shields.io/badge/style-neostandard-ff80ff?style=flat)](https://github.com/neostandard/neostandard#readme-badges)
+[![Code Coverage](https://img.shields.io/codecov/c/github/arb/celebrate?style=flat&logo=codecov)](https://codecov.io/gh/arb/celebrate)
+[![Total Downloads](https://img.shields.io/npm/dt/celebrate?style=flat&color=cyan)](https://www.npmjs.org/package/celebrate)
 
 
 celebrate is an express middleware function that wraps the [joi](https://github.com/hapijs/joi/tree/master) validation library. This allows you to use this middleware in any single route, or globally, and ensure that all of your inputs are correct before any handler function. The middleware allows you to validate `req.params`, `req.headers`, and `req.query`.

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 [![celebrate](https://github.com/arb/celebrate/raw/master/images/logo.svg?sanitize=1)](https://www.npmjs.org/package/celebrate)
 
-[![Current Version](https://img.shields.io/npm/v/celebrate?style=flat)](https://www.npmjs.org/package/celebrate)
-[![Build Status](https://img.shields.io/github/actions/workflow/status/arb/celebrate/ci.yml?branch=master&style=flat&label=build&logo=github)](https://github.com/arb/celebrate/actions/workflows/ci.yml)
-[![Neo Standard](https://img.shields.io/badge/style-neostandard-ff80ff?style=flat)](https://github.com/neostandard/neostandard#readme-badges)
-[![Code Coverage](https://img.shields.io/codecov/c/github/arb/celebrate?style=flat&logo=codecov)](https://codecov.io/gh/arb/celebrate)
-[![Total Downloads](https://img.shields.io/npm/dt/celebrate?style=flat&color=cyan)](https://www.npmjs.org/package/celebrate)
+[![Current Version](https://img.shields.io/npm/v/celebrate?style=for-the-badge)](https://www.npmjs.org/package/celebrate)
+[![Build Status](https://img.shields.io/github/actions/workflow/status/arb/celebrate/ci.yml?branch=master&style=for-the-badge&label=build&logo=github)](https://github.com/arb/celebrate/actions/workflows/ci.yml)
+[![Neo Standard](https://img.shields.io/badge/style-neostandard-ff80ff?style=for-the-badge)](https://github.com/neostandard/neostandard#readme-badges)
+[![Code Coverage](https://img.shields.io/codecov/c/github/arb/celebrate?style=for-the-badge&logo=codecov)](https://codecov.io/gh/arb/celebrate)
+[![18mo Downloads](https://img.shields.io/npm/d18m/celebrate?style=for-the-badge&color=cyan)](https://www.npmjs.org/package/celebrate)
 
 
 celebrate is an express middleware function that wraps the [joi](https://github.com/hapijs/joi/tree/master) validation library. This allows you to use this middleware in any single route, or globally, and ensure that all of your inputs are correct before any handler function. The middleware allows you to validate `req.params`, `req.headers`, and `req.query`.


### PR DESCRIPTION
## What

Move all five README badges from `badgen.net` to `img.shields.io`, all using `style=flat`.

## Why

The build-status badge had been showing `500` because `badgen.net`'s `github/checks` endpoint is currently returning HTTP 500. That endpoint depends on an authenticated GitHub API token that badgen has to maintain server-side, and it's been intermittently broken for a while. badgen.net itself is also effectively unmaintained at this point.

The other badgen badges (`npm/v`, `codecov/c`, `npm/dt`) still work fine because they hit public unauthenticated APIs, but rather than leave a mixed setup where one provider is partially broken, this PR moves the whole row to a single, actively-maintained provider so they fail or succeed together.

## How

Each badge image URL is swapped for its shields.io equivalent. Link targets are unchanged except for the build badge, which now correctly points at the Actions workflow runs page instead of the repo root. Colors (`ff80ff`, `cyan`) and icons (`github`, `codecov`) are preserved. All five badges share `style=flat` so the row is visually consistent.

shields.io's `flat` and badgen's `flat` aren't pixel-identical, but they're very close, and having all five badges from the same provider with the same style parameter is the bigger consistency win.