### PR TITLE
ci: bump checkout/setup-node to v5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,9 +20,9 @@ jobs:
         node-version: [20.x, 22.x, 24.x, 25.x]
         express-version: [latest-4, latest]
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v5
       with:
         node-version: ${{ matrix.node-version }}
     - run: npm pkg set "devDependencies.express=${{ matrix.express-version }}"
@@ -33,8 +33,8 @@ jobs:
   coverage:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-node@v4
+    - uses: actions/checkout@v5
+    - uses: actions/setup-node@v5
       with:
         node-version: 22.x
     - run: npm install

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ complexity.md
 coverage/**
 **/package-lock.json
 .nova/**
+.cursor/**


### PR DESCRIPTION
v5 of these actions runs on Node 24 inside the runner, which silences the "Node.js 20 actions are deprecated" warnings GitHub started emitting on every job. Pure hygiene; no behavioral change to the test or build steps.

Originally drafted as part of #265 but pushed after that PR was already merged, so landing it standalone here.

Made with [Cursor](https://cursor.com)